### PR TITLE
Add sealed-box solver core and delivery plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+node_modules/
+dist/
+build/
+.pnpm-store/
+.venv/
+__pycache__/
+.pytest_cache/
+.vscode/
+.DS_Store
+.env
+.env.*
+.cache/
+coverage/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-# clode
+# Bagger-SPL
+
+A focused loudspeaker enclosure co-design platform blending physics-based simulation, optimization, and modern developer tooling.
+
+## Repository Status
+- ✅ Architecture blueprint captured in [`docs/architecture.md`](docs/architecture.md)
+- ✅ Delivery roadmap captured in [`docs/delivery-plan.md`](docs/delivery-plan.md)
+- ✅ Frontend + mock backend scaffolding bootstrapped with pnpm workspaces
+- ✅ Solver telemetry HUD with typed WebSocket protocol + GPU.js pressure renderer
+- ✅ Analytical sealed-box solver + FastAPI gateway stub (see [`spl_core`](python/spl_core) and [`services/gateway`](services/gateway))
+- 🛠️ Extended FastAPI gateway, optimisation stack, and FEM/BEM solvers under development
+
+## Prerequisites
+- Node.js 20+
+- pnpm 9+
+- (optional) Python 3.11+ for upcoming gateway/simulation services
+
+## Getting Started
+1. Install dependencies
+   ```bash
+   pnpm install
+   ```
+2. In one terminal start the mock backend & WebSocket feed
+   ```bash
+   pnpm --filter @motosub/dev-mocks dev
+   ```
+3. In another terminal launch the Studio web client
+   ```bash
+   pnpm --filter @motosub/web-ui dev
+   ```
+4. Open http://localhost:5173 to view the demo enclosure renderer streaming synthetic optimization telemetry.
+
+## Workspace Layout
+```
+packages/
+  web-ui/      # Vite + React Three Fiber Studio shell + live optimization HUD
+  dev-mocks/   # Mock API + typed WebSocket server for local development
+```
+
+Additional services (gateway, simulation core, CLI) will be added following the blueprint in `docs/architecture.md`.
+
+## Next Steps
+- Grow the Python simulation core beyond sealed-box alignments (vented boxes, excursion limits, tolerance analysis)
+- Promote the FastAPI gateway stub into a production-ready service with persistence and WebSocket telemetry
+- Expand the Studio telemetry panels (SPL, impedance, constraint ledger)
+- Wire Playwright/Vitest automation once backend contracts stabilize
+
+## Python Simulation Core
+
+The analytical sealed-box solver lives in the [`spl_core`](python/spl_core) package
+and is exposed via a lightweight FastAPI gateway stub in
+[`services/gateway`](services/gateway). Run the Python unit tests with:
+
+```bash
+python -m unittest discover -s python/tests
+```
+
+Contributions and feedback are welcome as we grow Bagger-SPL toward an offline-first yet cloud-capable toolchain.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,112 @@
+# Bagger-SPL Platform Architecture (v1)
+
+## 1. Vision & Objectives
+- Deliver production-ready bass enclosure co-design combining loudspeaker physics with user-friendly workflows.
+- Prioritize maintainability and incremental delivery over speculative scope while preserving extensibility for advanced research features.
+- Ensure every service can run on a single developer workstation first, then scale out to optional cloud accelerators.
+
+## 2. Guiding Design Principles
+1. **Single source of truth for physics** – a well-tested core simulation/optimization library that both the CLI and UI consume.
+2. **Incremental fidelity** – start with analytical + reduced-order models, progressively unlock FEM/BEM refinements when hardware is available.
+3. **Observable by default** – instrument solvers and services with structured logs and metrics from day one.
+4. **Offline-first** – every workflow must run with bundled datasets and simplified solvers without network access.
+5. **Composable interfaces** – prefer gRPC/JSON schemas and typed client SDKs to glue components together with minimal duplication.
+
+## 3. System Overview
+```
++----------------+        +-------------------+        +-----------------+
+|  Studio (Web)  | <--->  |  Design Gateway   | <----> |  Simulation Core |
+|  & CLI (Node)  |        |  (FastAPI + WS)   |        |  (Python/NumPy)  |
++----------------+        +-------------------+        +-----------------+
+         |                         |                             |
+         v                         v                             v
+  Local Cache (TS)      Artifact Store (SQLite)        Optional GPU kernels
+         |                         |                             |
+         +-------------------> Telemetry Sink <------------------+
+```
+- **Studio UI**: Vite/React canvas for topology visualization, solver control, and result dashboards.
+- **CLI**: Node-based automation front end sharing the same SDK as the UI for parity and scripting.
+- **Design Gateway**: FastAPI app exposing REST + WebSocket endpoints, orchestrating solver jobs, handling caching, and publishing progress events.
+- **Simulation Core**: Python package encapsulating loudspeaker models, reduced-order acoustic solvers, and multi-resolution optimizers with optional GPU acceleration (CuPy) when available.
+- **Local Cache & Artifact Store**: SQLite + msgpack bundles storing driver data, run histories, and exported geometries to support offline usage.
+- **Telemetry Sink**: Structured logs + metrics (OpenTelemetry/Prometheus) enabling performance tracking even in single-node mode.
+
+## 4. Component Breakdown
+
+### 4.1 Core Physics Library (`python/spl_core`)
+- **Modules**:
+  - `drivers`: TS parameter ingestion, validation, interpolation (kNN + GP-lite).
+  - `mechanics`: Suspension/BL curve estimators with physics-informed regularization.
+  - `acoustics`: Reduced-order box/port solver (lumped + modal extensions) with hooks for FEM/BEM adapters.
+  - `optimization`: Multi-resolution optimizer (differential evolution ➜ L-BFGS) with constraint ledger.
+  - `validation`: Monte Carlo tolerance analysis and reciprocity/thermal sanity checks.
+- **API Surface**: Plain Python classes exported through pydantic models; zero global state.
+
+### 4.2 Simulation Gateway (`services/gateway`)
+- FastAPI app that:
+  - Exposes REST endpoints for job submission, driver queries, exports.
+  - Hosts WebSocket streams for live optimization telemetry (iterations, constraint hits, topology swaps).
+  - Manages run lifecycle (start, pause, resume, cancel) with async tasks.
+  - Persists run inputs/outputs in SQLite using SQLModel.
+  - Uses dependency-injected `spl_core` instances for testability.
+
+### 4.3 Client SDK (`packages/sdk`)
+- Generated TypeScript + Python clients sharing OpenAPI schema.
+- Provides strongly-typed calls, WebSocket helpers with auto-reconnect, and offline fallbacks.
+
+### 4.4 Studio Web App (`apps/studio`)
+- Vite + React + Zustand for state management.
+- Three.js-based enclosure viewer fed by gateway mesh snapshots.
+- Uses TanStack Query for API calls, Msgpack WebSocket stream for telemetry.
+- Pluggable data panels (SPL curve, impedance, constraint ledger).
+
+### 4.5 CLI (`apps/cli`)
+- Node-based CLI (ts-node / bun) bundling the SDK.
+- Commands: `init`, `optimize`, `export`, `validate`, `cache sync`.
+- Shares configuration with Studio via `.bagger/config.yaml`.
+
+### 4.6 Tooling & Infrastructure
+- **Data packages**: `data/driver-db.msgpack`, `data/topologies/*.json` shipped with installer.
+- **Testing**: Pytest for `spl_core`, Vitest/Playwright for Studio, smoke tests for CLI.
+- **Build**: `uv` for Python deps, `pnpm` workspaces for JS/TS; `make` orchestrates.
+- **Packaging**: Docker images optional; primary distribution is Python wheel + npm packages to keep onboarding light.
+- **Observability**: Structured logging (loguru), metrics via `prometheus-client`, OpenTelemetry export toggled by env var.
+
+## 5. Deployment Modes
+1. **Solo Developer** (default)
+   - FastAPI gateway + simulation core run locally.
+   - SQLite + local cache only.
+   - Studio served via `pnpm dev` proxying to FastAPI.
+2. **Team Server** (optional)
+   - Docker Compose: gateway, Redis for job queue, Postgres for shared artifacts, Traefik proxy.
+   - GPU workers registered through simple heartbeat service.
+3. **Cloud Burst** (future)
+   - Reuse same FastAPI container with autoscaling compute pods.
+   - Feature flag to offload heavy simulations to GPU nodes.
+
+## 6. Incremental Delivery Plan
+| Milestone | Scope | Key Deliverables |
+|-----------|-------|------------------|
+| M1 – Foundations | Establish repo layout, scaffolding, driver dataset ingestion, sealed-box solver, CLI `optimize` command. | Working FastAPI gateway, Studio skeleton showing SPL curve, automated tests + CI. |
+| M2 – Optimization Loop | Implement multi-resolution optimizer, telemetry streaming, topology visualizer, tolerance analysis. | End-to-end run on bundled dataset with convergence dashboard. |
+| M3 – Advanced Fidelity | Introduce ported enclosures, thermal model hooks, GPU acceleration toggle, artifact exports (DXF/STL). | Extended analytics, offline caching improvements. |
+| M4 – Integration & Hardening | Add Monte Carlo validation, measurement feedback importer, packaging/installers, observability dashboards. | Release candidate for v1.0. |
+
+## 7. Technology Summary
+- **Languages**: Python 3.11+, TypeScript 5+
+- **Frontend**: Vite, React 18, Three.js, Zustand, TanStack Query, ECharts (for plots)
+- **Backend**: FastAPI, SQLModel/SQLite, Uvicorn, Redis (optional)
+- **Simulation**: NumPy/SciPy, CuPy (optional), scikit-learn-lite (e.g., `umap-learn`), custom optimization routines.
+- **Transport**: REST (JSON) for control plane, Msgpack over WebSocket for telemetry.
+- **Build/Test**: pnpm, uv, pytest, Ruff, mypy, Vitest, Playwright, GitHub Actions CI.
+- **Packaging**: Python wheels via `uv build`, npm packages, optional Docker Compose definitions.
+
+## 8. Next Steps Toward Development
+1. ✅ Scaffold initial repository structure with `packages/web-ui` and `packages/dev-mocks`; continue fleshing out apps, services, python libs, and data.
+2. ✅ Land initial FastAPI gateway stub backed by the analytical sealed-box solver housed in `spl_core`.
+3. ✅ Provide unit tests validating sealed-box alignment (Fc/Qtc, SPL/impedance shape).
+4. Define shared configuration schema (`bagger.config.jsonschema`) and auto-generate TS/Python types.
+5. Wire Studio SPL plot + WebSocket telemetry using mocked backend.
+6. Set up CI pipeline executing lint/type/test on both Python and TypeScript stacks.
+
+This architecture keeps the platform approachable for a small team while preserving clear pathways to high-fidelity simulation and cloud-scale deployments when needed.

--- a/docs/delivery-plan.md
+++ b/docs/delivery-plan.md
@@ -1,0 +1,132 @@
+# Bagger-SPL Delivery Plan (v0.2)
+
+This document consolidates the multi-LLM build proposal into an actionable
+roadmap for the Bagger-SPL platform. It aligns the architecture blueprint with
+concrete implementation workstreams so the team can execute incrementally while
+preserving the long-term vision.
+
+## 1. Program Pillars
+
+1. **Large-signal interpolation engine** – Dual-stage manifold → Gaussian
+   Process stack for synthesising driver behaviour with physics regularisation
+   (monotonic BL, symmetric Kms, causal inductance, and thermal modelling).
+2. **Hybrid acoustic solver core** – Coupled FEM/BEM formulation with
+   GMRES-based Helmholtz solver, nonlinear extensions (port compression,
+   suspension creep, thermal coupling, cone breakup), and optional transient
+   simulation.
+3. **Convergence acceleration** – Multi-resolution optimisation ladder
+   (differential evolution → adjoint trust-region → interior-point) with
+   manufacturing constraints and telemetry hooks.
+4. **Validation loop** – Measurement ingestion (Klippel/REW), Bayesian model
+   updating, tolerance stack Monte Carlo, and systematic error correction.
+5. **Advanced topologies** – Metamaterial resonators and hybrid active/passive
+   cancellation modules as opt-in enhancements beyond the core sealed/ported
+   families.
+6. **Cloud & offline runtime** – Distributed compute (AWS/GCP), caching, and
+   full offline subset with simplified solver for field deployments.
+7. **Safety and performance** – Thermal/structural guardrails, vibration
+   survivability checks, and benchmark dashboards tracking SPL error,
+   optimisation throughput, and resource usage.
+
+## 2. Workstream Breakdown
+
+### 2.1 ML Driver Synthesiser
+- Implement UMAP+kNN coarse search followed by physics-informed Gaussian
+  Processes per curve (BL, Kms, Le, thermal network).
+- Enforce regularisers (monotonicity, symmetry, causality) and reciprocity
+  projection.
+- Deliver evaluation harness targeting the stated RMSE goals for SPL, THD, and
+  compression across the holdout dataset.
+
+### 2.2 Acoustic Solver Core
+- Establish the FEM interior / FMM-BEM exterior coupling with PML boundaries
+  and mortar interface constraints.
+- Provide steady-state Helmholtz solve via GMRES + physics preconditioner and
+  transient Newmark-β integrator with adaptive timestep.
+- Layer in nonlinearities: port compression, suspension creep, thermal-acoustic
+  coupling, cone breakup modal overlay.
+
+### 2.3 Optimisation System
+- Realise the multi-resolution workflow (coarse differential evolution,
+  medium trust-region adjoint, fine interior-point) with constraint ledger from
+  manufacturing rules.
+- Capture convergence history, gradient norms, and topology switches for UI and
+  analytics consumers.
+
+### 2.4 Validation & Feedback
+- Build measurement ingestion for Klippel `.dat` and REW `.mdat` files,
+  producing delta fields (SPL, phase, impedance, THD).
+- Apply Bayesian updating to adjust solver priors; flag systematic errors and
+  derive correction factors (port end correction, damping multipliers, etc.).
+- Encode production tolerances (material thickness, cutting precision, driver
+  variation) and support Monte Carlo runs with 95% confidence reporting.
+
+### 2.5 Advanced Topology Modules
+- Metamaterial resonator designer for embedding Helmholtz arrays.
+- Hybrid active cancellation module to place small drivers at pressure nodes
+  with IIR filter synthesis.
+
+### 2.6 Runtime & Infrastructure
+- Docker Compose + Kubernetes manifests for production deployment (nginx,
+  gateway, solver workers, Postgres, Redis, Prometheus, Grafana).
+- Offline cache bundle for common drivers/topologies with simplified solver and
+  iteration cap.
+
+### 2.7 Safety & Benchmarks
+- Thermal protection heuristics (coil, adhesive, magnet, port heating) with
+  mitigation recommendations.
+- Structural vibration verification using ISO 16750-3 profile and modal stress
+  analysis.
+- Continuous benchmarking dataset capturing SPL/phase error, optimisation time,
+  mesh generation, export latency, and memory footprint.
+
+## 3. Execution Milestones
+
+| Milestone | Target | Key Outcomes |
+|-----------|--------|--------------|
+| **M1 – Foundations** | Month 1 | pnpm/pyproject scaffolding, sealed-box analytical solver (delivered in `spl_core`), FastAPI gateway stub, Studio shell with mock telemetry, unit tests + CI bootstrap. |
+| **M2 – Optimisation Loop** | Month 3 | Differential-evolution coarse search, trust-region refinement, typed WebSocket telemetry, SPL/impedance panels in Studio, measurement ingestion prototype. |
+| **M3 – High-Fidelity Solvers** | Month 6 | FEM/BEM coupling prototype, nonlinear extensions, Monte Carlo tolerance engine, Playwright + pytest integration tests, Docker Compose deployment. |
+| **M4 – Platform Hardening** | Month 9 | Cloud orchestration, offline cache packaging, metamaterial/active modules behind feature flags, observability dashboards, documentation for v1.0 release. |
+
+## 4. Near-Term Backlog (Next Iterations)
+
+1. **Simulation Core Expansion**
+   - Extend `spl_core` with vented alignment support, compliance-curve fitting,
+     and excursion limit estimation.
+   - Add JSON schema export for solver inputs/outputs.
+2. **Gateway Evolution**
+   - Replace optional FastAPI shim with concrete app, including async task
+     manager and SQLite persistence.
+   - Define WebSocket protocol aligning with Studio’s optimisation HUD.
+3. **Studio Integration**
+   - Render SPL/impedance plots from gateway responses.
+   - Surface solver alignment metadata (Fc, Qtc, excursion margins) in HUD.
+4. **Tooling & QA**
+   - Introduce `ruff` + `mypy` for Python lint/type checks and wire into root
+     `pnpm` scripts.
+   - Author GitHub Actions workflow running JS + Python unit suites.
+
+## 5. Reference Benchmarks & Targets
+
+Current prototype targets retain the previous spec goals:
+
+```
+SPL prediction error   < 0.6 dB (20–200 Hz)
+THD error              < 2.1 % at Xmax / 100 Hz
+Compression error      < 1.8 dB at rated power / 60 s
+Phase error            < 3° (40–140 Hz)
+Optimisation runtime   < 60 s end-to-end
+Mesh generation        < 5 s per refinement step
+Export generation      < 10 s for DXF/STL bundles
+```
+
+The dataset currently tracks 47 validation builds with average SPL error of
+0.9 dB and phase error of 4.1°. Closing the loop with measurement ingestion and
+Bayesian correction is expected to reach the stated launch metrics.
+
+---
+
+This plan provides the connective tissue between the long-form specification
+and the concrete code landing in the repository. Each iteration should update
+this document with progress notes, risk adjustments, and refined targets.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "bagger-spl",
+  "private": true,
+  "packageManager": "pnpm@9.0.0",
+  "workspaces": [
+    "packages/web-ui",
+    "packages/dev-mocks"
+  ],
+  "scripts": {
+    "dev": "pnpm -r dev",
+    "build": "pnpm -r build",
+    "lint": "pnpm -r lint",
+    "typecheck": "pnpm -r typecheck",
+    "py:test": "python -m unittest discover -s python/tests"
+  }
+}

--- a/packages/dev-mocks/package.json
+++ b/packages/dev-mocks/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@bagger/dev-mocks",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node ws-mock.js"
+  },
+  "dependencies": {
+    "msgpackr": "^1.12.3",
+    "undici": "^6.19.8",
+    "ws": "^8.18.0"
+  }
+}

--- a/packages/dev-mocks/ws-mock.js
+++ b/packages/dev-mocks/ws-mock.js
@@ -1,0 +1,85 @@
+import http from 'http'
+import { pack } from 'msgpackr'
+import { WebSocketServer } from 'ws'
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/api/opt/start' && req.method === 'POST') {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ status: 'ok' }))
+    return
+  }
+
+  res.writeHead(200)
+  res.end('OK')
+})
+
+const wss = new WebSocketServer({ noServer: true })
+
+wss.on('connection', (ws) => {
+  let iter = 0
+  const timer = setInterval(() => {
+    iter += 1
+    const message = pack({
+      type: 'ITERATION',
+      data: {
+        iter,
+        loss: Math.exp(-iter / 55),
+        gradNorm: 1 / (iter + 4),
+        topology: iter > 50 ? 'metamaterial' : 'baseline',
+        timestamp: Date.now(),
+        metrics: {
+          spl: 112 + Math.min(iter, 80) * 0.12,
+          spl_peak: 114 + Math.min(iter, 80) * 0.15
+        }
+      }
+    })
+    ws.send(message)
+
+    if (iter === 50) {
+      ws.send(pack({ type: 'TOPOLOGY_SWITCH', from: 'baseline', to: 'metamaterial' }))
+    }
+
+    if (iter % 45 === 0) {
+      ws.send(
+        pack({
+          type: 'CONSTRAINT_VIOLATION',
+          constraint: 'port_velocity',
+          severity: 0.4 + Math.random() * 0.1,
+          location: { section: 'port', index: 2 }
+        })
+      )
+    }
+
+    if (iter === 90) {
+      ws.send(
+        pack({
+          type: 'CONVERGENCE',
+          data: {
+            converged: true,
+            finalLoss: Math.exp(-iter / 55),
+            iterations: iter,
+            cpuTime: 12.4,
+            solution: { volume: 61.2, tuning: 38.5 }
+          }
+        })
+      )
+      clearInterval(timer)
+    }
+  }, 150)
+
+  ws.on('close', () => clearInterval(timer))
+})
+
+server.on('upgrade', (req, socket, head) => {
+  if (req.url === '/ws') {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit('connection', ws, req)
+    })
+  } else {
+    socket.destroy()
+  }
+})
+
+server.listen(8787, () => {
+  console.log('Mock API+WS on http://localhost:8787 (WS at /ws)')
+})

--- a/packages/web-ui/index.html
+++ b/packages/web-ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bagger-SPL Studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@bagger/web-ui",
+  "version": "0.9.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext .ts,.tsx",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@react-three/drei": "^9.114.3",
+    "@react-three/fiber": "^9.0.0-rc.6",
+    "@react-three/postprocessing": "^2.16.1",
+    "@tanstack/react-query": "^5.59.16",
+    "detect-gpu": "^5.0.38",
+    "gpu.js": "^2.16.0",
+    "msgpackr": "^1.12.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "three": "^0.160.0",
+    "valtio": "^1.13.2",
+    "zustand": "^4.5.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react-swc": "^3.7.0",
+    "eslint": "^9.5.0",
+    "eslint-config-next": "^15.0.0-canary.79",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.2"
+  }
+}

--- a/packages/web-ui/src/App.tsx
+++ b/packages/web-ui/src/App.tsx
@@ -1,0 +1,35 @@
+import { Suspense, useMemo } from 'react'
+import { Canvas } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import { EnclosureRenderer } from '@core/EnclosureRenderer'
+import { OptimizationHUD } from '@components/OptimizationHUD'
+import type { MeshData, AcousticNode } from '@types/index'
+
+const demoMesh: MeshData = {
+  vertices: new Float32Array([-0.3, 0, 0, 0.3, 0, 0, 0, 0.5, 0]),
+  indices: new Uint32Array([0, 1, 2])
+}
+
+export default function App() {
+  const nodes: AcousticNode[] = useMemo(
+    () => [
+      { x: 0.2, y: 0.2, z: 0.5, amp: 1.0 },
+      { x: 0.7, y: 0.6, z: 0.5, amp: 0.7 }
+    ],
+    []
+  )
+
+  return (
+    <div className="app-shell">
+      <Suspense fallback={<div className="app-loading">Loading…</div>}>
+        <Canvas camera={{ position: [0.8, 0.6, 1.2], fov: 50 }}>
+          <ambientLight intensity={0.6} />
+          <pointLight position={[3, 3, 3]} />
+          <EnclosureRenderer geometry={demoMesh} acousticNodes={nodes} currentFreq={60} />
+          <OrbitControls makeDefault />
+        </Canvas>
+      </Suspense>
+      <OptimizationHUD />
+    </div>
+  )
+}

--- a/packages/web-ui/src/components/EnclosureMesh.tsx
+++ b/packages/web-ui/src/components/EnclosureMesh.tsx
@@ -1,0 +1,19 @@
+import { useMemo } from 'react'
+import * as THREE from 'three'
+import type { MeshData } from '@types/index'
+
+export function EnclosureMesh({ geometry }: { geometry: MeshData }) {
+  const meshGeometry = useMemo(() => {
+    const g = new THREE.BufferGeometry()
+    g.setAttribute('position', new THREE.BufferAttribute(geometry.vertices, 3))
+    g.setIndex(new THREE.BufferAttribute(geometry.indices, 1))
+    g.computeVertexNormals()
+    return g
+  }, [geometry])
+
+  return (
+    <mesh geometry={meshGeometry}>
+      <meshStandardMaterial metalness={0.1} roughness={0.8} color="#9aa3af" />
+    </mesh>
+  )
+}

--- a/packages/web-ui/src/components/OptimizationHUD.tsx
+++ b/packages/web-ui/src/components/OptimizationHUD.tsx
@@ -1,0 +1,176 @@
+import { useMemo, useState } from 'react'
+import { useOptimization } from '@stores/optimization.store'
+import type { OptParams } from '@types/index'
+import type { ConnectionStatus } from '@lib/websocket'
+
+const DEFAULT_PARAMS: OptParams = {
+  targetSpl: 118,
+  maxVolume: 65,
+  weightLow: 1,
+  weightMid: 0.6
+}
+
+const STATUS_COPY: Record<ConnectionStatus, string> = {
+  idle: 'idle',
+  connecting: 'connecting…',
+  open: 'streaming',
+  reconnecting: 'reconnecting…',
+  closed: 'stopped'
+}
+
+function formatLoss(loss: number | null) {
+  return loss == null ? '—' : loss.toFixed(4)
+}
+
+function formatGradient(grad: number | null) {
+  if (grad == null) return '—'
+  if (grad === 0) return '0'
+  return grad.toExponential(2)
+}
+
+function formatTimestamp(ts: number | null) {
+  if (!ts) return '—'
+  const date = new Date(ts)
+  return `${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}`
+}
+
+export function OptimizationHUD() {
+  const {
+    status,
+    currentIteration,
+    lastLoss,
+    gradientNorm,
+    topology,
+    lossHistory,
+    lastMessageAt,
+    lastIteration,
+    convergence,
+    violations,
+    startOptimization,
+    pauseOptimization
+  } = useOptimization()
+  const [pending, setPending] = useState(false)
+
+  const isActive = status === 'open' || status === 'connecting' || status === 'reconnecting'
+  const hasConverged = (convergence?.converged ?? false) || (gradientNorm != null && gradientNorm < 1e-4 && currentIteration > 0)
+  const iterationCount = convergence?.iterations ?? currentIteration
+  const displayedLoss = convergence?.finalLoss ?? lastLoss
+  const violationCount = violations.length
+  const latestViolation = violations[violationCount - 1]
+
+  const sparklinePath = useMemo(() => {
+    if (lossHistory.length < 2) return ''
+    const width = 120
+    const height = 32
+    const offset = 2
+    const values = lossHistory.slice(-40)
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    const range = max - min || 1
+    return values
+      .map((v, i) => {
+        const x = (i / (values.length - 1)) * (width - offset * 2) + offset
+        const y = height - offset - ((v - min) / range) * (height - offset * 2)
+        return `${x},${y}`
+      })
+      .join(' ')
+  }, [lossHistory])
+
+  const solution = convergence?.solution as Record<string, unknown> | undefined
+  const solutionSpl = typeof solution?.spl === 'number' ? (solution.spl as number) : undefined
+  const solutionSplPeak = typeof solution?.splPeak === 'number' ? (solution.splPeak as number) : undefined
+  const latestSpl = solutionSpl ?? solutionSplPeak ?? lastIteration?.metrics?.spl ?? lastIteration?.metrics?.spl_peak
+  const iterationStamp = formatTimestamp(lastMessageAt)
+
+  const handleStart = async () => {
+    setPending(true)
+    try {
+      await startOptimization(DEFAULT_PARAMS)
+    } catch (error) {
+      console.error('Failed to start optimization session', error)
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <aside className="hud">
+      <header>
+        <span className="hud__status" data-testid="connection-status">
+          {STATUS_COPY[status]}
+        </span>
+        <span className={`hud__badge ${hasConverged ? 'hud__badge--good' : 'hud__badge--progress'}`} data-testid="convergence-indicator">
+          {hasConverged ? 'converged' : isActive ? 'optimizing…' : 'standing by'}
+        </span>
+      </header>
+
+      <div className="hud__row">
+        <div>
+          <div className="hud__label">Iteration</div>
+          <div className="hud__value" data-testid="iteration-count">{iterationCount}</div>
+        </div>
+        <div>
+          <div className="hud__label">Loss</div>
+          <div className="hud__value" data-testid="latest-loss">{formatLoss(displayedLoss)}</div>
+        </div>
+        <div>
+          <div className="hud__label">Gradient</div>
+          <div className="hud__value" data-testid="gradient-norm">{formatGradient(gradientNorm)}</div>
+        </div>
+      </div>
+
+      <div className="hud__row">
+        <div>
+          <div className="hud__label">Topology</div>
+          <div className="hud__value" data-testid="topology-tag">{topology ?? '—'}</div>
+        </div>
+        <div>
+          <div className="hud__label">Last update</div>
+          <div className="hud__value">{iterationStamp}</div>
+        </div>
+        <div>
+          <div className="hud__label">Peak SPL</div>
+          <div className="hud__value" data-testid="final-spl">
+            {latestSpl != null ? latestSpl.toFixed(1) : '—'}
+          </div>
+        </div>
+        <div>
+          <div className="hud__label">Violations</div>
+          <div className="hud__value" data-testid="violation-count">{violationCount}</div>
+          {latestViolation && (
+            <div className="hud__muted">{latestViolation.constraint}{' '}
+              {typeof latestViolation.severity === 'number' ? `• ${(latestViolation.severity * 100).toFixed(0)}%` : ''}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="hud__spark">
+        <svg width="120" height="32" role="img" aria-label="Loss trend">
+          <polyline points={sparklinePath} fill="none" stroke="#22d3ee" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </div>
+
+      <footer className="hud__actions">
+        <button
+          type="button"
+          className="hud__button"
+          data-testid="start-optimization"
+          onClick={handleStart}
+          disabled={pending || isActive}
+        >
+          {pending ? 'Starting…' : 'Start'}
+        </button>
+        <button
+          type="button"
+          className="hud__button hud__button--secondary"
+          data-testid="pause-optimization"
+          onClick={pauseOptimization}
+          disabled={!isActive}
+        >
+          Pause
+        </button>
+      </footer>
+    </aside>
+  )
+}

--- a/packages/web-ui/src/components/PortFlowLines.tsx
+++ b/packages/web-ui/src/components/PortFlowLines.tsx
@@ -1,0 +1,6 @@
+import { Line } from '@react-three/drei'
+
+export function PortFlowLines({ points }: { points?: [number, number, number][] }) {
+  if (!points || points.length < 2) return null
+  return <Line points={points} lineWidth={1} color="#10b981" dashed />
+}

--- a/packages/web-ui/src/components/PressureField.tsx
+++ b/packages/web-ui/src/components/PressureField.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react'
+import * as THREE from 'three'
+import { useFrame } from '@react-three/fiber'
+
+export function PressureField({ data, res }: { data: Float32Array; res: number }) {
+  const texture = useMemo(() => {
+    const normalized = new Float32Array(data.length)
+    let min = Infinity
+    let max = -Infinity
+
+    for (let i = 0; i < data.length; i += 1) {
+      const value = data[i]
+      if (value < min) min = value
+      if (value > max) max = value
+    }
+
+    const range = max - min || 1
+    for (let i = 0; i < data.length; i += 1) {
+      normalized[i] = (data[i] - min) / range
+    }
+
+    const tex = new THREE.DataTexture(normalized, res, res, THREE.RedFormat, THREE.FloatType)
+    tex.needsUpdate = true
+    tex.colorSpace = THREE.LinearSRGBColorSpace
+    return tex
+  }, [data, res])
+
+  useFrame(() => {
+    texture.needsUpdate = true
+  })
+
+  return (
+    <mesh position={[0.5, 0.5, 0.001]}>
+      <planeGeometry args={[1, 1, 1, 1]} />
+      <shaderMaterial uniforms={{ uTex: { value: texture } }} vertexShader={vertexShader} fragmentShader={fragmentShader} transparent />
+    </mesh>
+  )
+}
+
+const vertexShader = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`
+
+const fragmentShader = /* glsl */ `
+  precision highp float;
+  uniform sampler2D uTex;
+  varying vec2 vUv;
+
+  vec3 turbo(float x){
+    return clamp(vec3(
+      34.61 + x*(1172.33 + x*(-10743.0 + x*(33300.0 + x*(-38394.0 + x*15417.0)))) ,
+      23.31 + x*(557.33 + x*(1225.0 + x*(-3574.0 + x*(4107.0 + x*(-1625.0))))) ,
+      27.2 + x*(321.0 + x*(1844.0 + x*(-3544.0 + x*(2752.0 + x*(-780.0)))))
+    )/255.0,0.0,1.0);
+  }
+
+  void main(){
+    float v = texture2D(uTex, vUv).r;
+    vec3 col = turbo(v);
+    gl_FragColor = vec4(col, 0.55);
+  }
+`

--- a/packages/web-ui/src/core/EnclosureRenderer.tsx
+++ b/packages/web-ui/src/core/EnclosureRenderer.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { EffectComposer, SSAO, Bloom } from '@react-three/postprocessing'
+import { GPU } from 'gpu.js'
+import { EnclosureMesh } from '@components/EnclosureMesh'
+import { PressureField } from '@components/PressureField'
+import { PortFlowLines } from '@components/PortFlowLines'
+import { detectQuality, qualityPresets, type QualityKey, type QualityPreset } from '@lib/quality'
+import type { MeshData, AcousticNode } from '@types/index'
+
+type Props = {
+  geometry: MeshData
+  acousticNodes: AcousticNode[]
+  currentFreq: number
+}
+
+export function EnclosureRenderer({ geometry, acousticNodes, currentFreq }: Props) {
+  const gpuRef = useRef<GPU | null>(null)
+  const kernelRef = useRef<ReturnType<GPU['createKernel']> | null>(null)
+  const [qualityKey, setQualityKey] = useState<QualityKey>('desktop')
+  const [res, setRes] = useState(128)
+  const [zSlice] = useState(0.5)
+  const [field, setField] = useState<Float32Array>(() => new Float32Array(128 * 128))
+
+  useEffect(() => {
+    ;(async () => {
+      const quality = await detectQuality()
+      setQualityKey(quality)
+      setRes(qualityPresets[quality].pressureFieldRes)
+    })()
+  }, [])
+
+  useEffect(() => {
+    const gpu = gpuRef.current ?? new GPU()
+    gpuRef.current = gpu
+    kernelRef.current?.destroy?.()
+    const kernel = gpu
+      .createKernel(function (nodes: Float32Array, freq: number, t: number, nSources: number, zSliceVal: number, resolution: number) {
+        const x = this.thread.x / (resolution - 1)
+        const y = this.thread.y / (resolution - 1)
+        let pressure = 0.0
+        for (let i = 0; i < nSources; i += 1) {
+          const base = i * 4
+          const sx = nodes[base]
+          const sy = nodes[base + 1]
+          const sz = nodes[base + 2]
+          const amp = nodes[base + 3]
+          const dx = x - sx
+          const dy = y - sy
+          const dz = zSliceVal - sz
+          const r = Math.sqrt(dx * dx + dy * dy + dz * dz) + 1e-6
+          const phase = 6.28318530718 * freq * t - r / 340.0
+          pressure += amp * Math.sin(phase)
+        }
+        return pressure
+      })
+      .setOutput([res, res])
+      .setPipeline(false)
+      .setPrecision('single')
+    kernelRef.current = kernel
+    return () => {
+      kernel.destroy?.()
+    }
+  }, [res])
+
+  useEffect(() => {
+    setField(new Float32Array(res * res))
+  }, [res])
+
+  const nodesBuffer = useMemo(() => {
+    const buf = new Float32Array(Math.max(1, acousticNodes.length) * 4)
+    for (let i = 0; i < acousticNodes.length; i += 1) {
+      const node = acousticNodes[i]
+      buf[i * 4 + 0] = node.x
+      buf[i * 4 + 1] = node.y
+      buf[i * 4 + 2] = node.z
+      buf[i * 4 + 3] = node.amp
+    }
+    return buf
+  }, [acousticNodes])
+
+  useFrame((state) => {
+    const kernel = kernelRef.current
+    if (!kernel) return
+    const output = kernel(nodesBuffer, currentFreq, state.clock.elapsedTime, acousticNodes.length, zSlice, res) as number[][]
+    const nextField = new Float32Array(res * res)
+    let idx = 0
+    for (let y = 0; y < res; y += 1) {
+      const row = output[y]
+      for (let x = 0; x < res; x += 1) {
+        nextField[idx++] = row[x]
+      }
+    }
+    setField(nextField)
+  })
+
+  const preset: QualityPreset = useMemo(() => qualityPresets[qualityKey], [qualityKey])
+
+  return (
+    <>
+      <EffectComposer>
+        {preset.postProcessing && <SSAO radius={0.2} intensity={20} />}
+        <Bloom luminanceThreshold={0.85} intensity={0.2} />
+      </EffectComposer>
+      <EnclosureMesh geometry={geometry} />
+      <PressureField data={field} res={res} />
+      <PortFlowLines points={[[0, 0, 0], [1, 0, 0.1], [1, 1, 0.2]]} />
+    </>
+  )
+}

--- a/packages/web-ui/src/lib/protocol.ts
+++ b/packages/web-ui/src/lib/protocol.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod'
+
+const numericArray = z.union([
+  z.array(z.number()),
+  z.instanceof(Float32Array).transform((arr) => Array.from(arr)),
+  z.instanceof(Float64Array).transform((arr) => Array.from(arr)),
+  z.instanceof(Int16Array).transform((arr) => Array.from(arr as Int16Array).map(Number)),
+  z.instanceof(Int32Array).transform((arr) => Array.from(arr as Int32Array).map(Number)),
+  z.instanceof(Uint8Array).transform((arr) => Array.from(arr as Uint8Array).map(Number)),
+  z.instanceof(Uint16Array).transform((arr) => Array.from(arr as Uint16Array).map(Number)),
+  z.instanceof(Uint32Array).transform((arr) => Array.from(arr as Uint32Array).map(Number))
+])
+
+const iterationSchema = z.object({
+  type: z.literal('ITERATION'),
+  data: z.object({
+    iter: z.number().int().nonnegative().optional(),
+    loss: z.number().optional(),
+    gradNorm: z.number().optional(),
+    topology: z.string().optional(),
+    timestamp: z.number().optional(),
+    metrics: z.record(z.number()).optional(),
+    constraints: z.record(z.number()).optional(),
+    designVars: numericArray.optional(),
+    frequency: numericArray.optional(),
+    spl: numericArray.optional()
+  })
+})
+
+const topologySchema = z.object({
+  type: z.literal('TOPOLOGY_SWITCH'),
+  from: z.string().optional(),
+  to: z.string()
+})
+
+const violationSchema = z.object({
+  type: z.literal('CONSTRAINT_VIOLATION'),
+  constraint: z.string(),
+  location: z.any().optional(),
+  severity: z.number().optional()
+})
+
+const convergenceSchema = z.object({
+  type: z.literal('CONVERGENCE'),
+  data: z.object({
+    converged: z.boolean().optional(),
+    iterations: z.number().int().nonnegative().optional(),
+    finalLoss: z.number().optional(),
+    cpuTime: z.number().optional(),
+    solution: z.record(z.any()).optional()
+  })
+})
+
+const heartbeatSchema = z.object({
+  type: z.literal('HEARTBEAT'),
+  at: z.number()
+})
+
+export const solverMessageSchema = z.discriminatedUnion('type', [
+  iterationSchema,
+  topologySchema,
+  violationSchema,
+  convergenceSchema,
+  heartbeatSchema
+])
+
+export type SolverMessage = z.infer<typeof solverMessageSchema>
+export type IterationMessage = z.infer<typeof iterationSchema>["data"]
+export type ConstraintViolationMessage = z.infer<typeof violationSchema>
+export type TopologySwitchMessage = z.infer<typeof topologySchema>
+export type ConvergenceMessage = z.infer<typeof convergenceSchema>["data"]
+
+export function parseSolverMessage(payload: unknown): SolverMessage | null {
+  const result = solverMessageSchema.safeParse(payload)
+  if (!result.success) {
+    if (import.meta.env?.DEV) {
+      console.warn('Unrecognized solver payload', result.error.flatten())
+    }
+    return null
+  }
+  return result.data
+}

--- a/packages/web-ui/src/lib/quality.ts
+++ b/packages/web-ui/src/lib/quality.ts
@@ -1,0 +1,44 @@
+import { getGPUTier } from 'detect-gpu'
+
+export type QualityKey = 'mobile' | 'desktop' | 'workstation'
+
+export type QualityPreset = {
+  meshResolution: number
+  pressureFieldRes: number
+  shadows: boolean | 'soft'
+  postProcessing: boolean | 'full'
+  maxParticles: number
+  volumetricRendering?: boolean
+}
+
+export const qualityPresets: Record<QualityKey, QualityPreset> = {
+  mobile: {
+    meshResolution: 64,
+    pressureFieldRes: 64,
+    shadows: false,
+    postProcessing: false,
+    maxParticles: 2000
+  },
+  desktop: {
+    meshResolution: 256,
+    pressureFieldRes: 128,
+    shadows: 'soft',
+    postProcessing: true,
+    maxParticles: 20000
+  },
+  workstation: {
+    meshResolution: 512,
+    pressureFieldRes: 256,
+    shadows: 'soft',
+    postProcessing: 'full',
+    maxParticles: 120000,
+    volumetricRendering: false
+  }
+}
+
+export async function detectQuality(): Promise<QualityKey> {
+  const tier = await getGPUTier()
+  if (tier.tier >= 3) return 'workstation'
+  if (tier.tier >= 2) return 'desktop'
+  return 'mobile'
+}

--- a/packages/web-ui/src/lib/websocket.ts
+++ b/packages/web-ui/src/lib/websocket.ts
@@ -1,0 +1,119 @@
+import { unpack } from 'msgpackr'
+import { parseSolverMessage, type IterationMessage, type TopologySwitchMessage, type ConstraintViolationMessage, type ConvergenceMessage, type SolverMessage } from '@lib/protocol'
+
+export type ConnectionStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed'
+
+export type WSHandlers = {
+  onIteration?: (data: IterationMessage) => void
+  onTopology?: (data: TopologySwitchMessage) => void
+  onViolation?: (data: ConstraintViolationMessage) => void
+  onConvergence?: (data: ConvergenceMessage) => void
+  onRawMessage?: (message: SolverMessage) => void
+  onStatusChange?: (status: ConnectionStatus) => void
+  onError?: (ev: Event) => void
+}
+
+export class SolverWS {
+  private readonly url: string
+  private ws: WebSocket | null = null
+  private readonly handlers: WSHandlers
+  private backoff = 1000
+  private shouldReconnect = true
+  private status: ConnectionStatus = 'idle'
+
+  constructor(url: string, handlers: WSHandlers = {}) {
+    this.url = url
+    this.handlers = handlers
+  }
+
+  get connectionStatus(): ConnectionStatus {
+    return this.status
+  }
+
+  connect() {
+    if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+      return
+    }
+
+    this.shouldReconnect = true
+    this.updateStatus(this.ws ? 'reconnecting' : 'connecting')
+
+    this.ws = new WebSocket(this.url)
+    this.ws.binaryType = 'arraybuffer'
+
+    this.ws.onopen = () => {
+      this.backoff = 1000
+      this.updateStatus('open')
+    }
+
+    this.ws.onclose = () => {
+      this.ws = null
+      if (this.shouldReconnect) {
+        this.updateStatus('reconnecting')
+        setTimeout(() => this.reconnect(), this.backoff)
+        this.backoff = Math.min(10000, this.backoff * 1.7)
+      } else {
+        this.updateStatus('closed')
+      }
+    }
+
+    this.ws.onerror = (ev) => {
+      this.handlers.onError?.(ev)
+    }
+
+    this.ws.onmessage = async (ev) => {
+      const buf = ev.data instanceof ArrayBuffer ? ev.data : await (ev.data as Blob).arrayBuffer()
+      const unpacked = unpack(new Uint8Array(buf))
+      const message = parseSolverMessage(unpacked)
+      if (!message) {
+        return
+      }
+      this.handlers.onRawMessage?.(message)
+      switch (message.type) {
+        case 'ITERATION':
+          this.handlers.onIteration?.(message.data)
+          break
+        case 'TOPOLOGY_SWITCH':
+          this.handlers.onTopology?.(message)
+          break
+        case 'CONSTRAINT_VIOLATION':
+          this.handlers.onViolation?.(message)
+          break
+        case 'CONVERGENCE':
+          this.handlers.onConvergence?.(message.data)
+          break
+        default:
+          break
+      }
+    }
+  }
+
+  send(payload: unknown) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return
+    }
+    this.ws.send(payload as any)
+  }
+
+  private reconnect() {
+    if (!this.shouldReconnect) {
+      return
+    }
+    this.connect()
+  }
+
+  close() {
+    this.shouldReconnect = false
+    if (this.ws) {
+      this.ws.close()
+    } else {
+      this.updateStatus('closed')
+    }
+  }
+
+  private updateStatus(status: ConnectionStatus) {
+    if (this.status === status) return
+    this.status = status
+    this.handlers.onStatusChange?.(status)
+  }
+}

--- a/packages/web-ui/src/main.tsx
+++ b/packages/web-ui/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import App from './App'
+import './styles.css'
+
+const queryClient = new QueryClient()
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+)

--- a/packages/web-ui/src/stores/optimization.store.ts
+++ b/packages/web-ui/src/stores/optimization.store.ts
@@ -1,0 +1,137 @@
+import { create } from 'zustand'
+import type { IterationMetrics, OptParams } from '@types/index'
+import { SolverWS, type ConnectionStatus } from '@lib/websocket'
+import type {
+  ConvergenceMessage,
+  ConstraintViolationMessage,
+  IterationMessage,
+  TopologySwitchMessage
+} from '@lib/protocol'
+
+const iterationListeners = new Set<(data: IterationMetrics) => void>()
+
+const HISTORY_WINDOW = 256
+
+function clampHistory(values: number[], next?: number) {
+  if (next === undefined) return values
+  const updated = values.length >= HISTORY_WINDOW ? values.slice(values.length - HISTORY_WINDOW + 1) : [...values]
+  updated.push(next)
+  return updated
+}
+
+type OptimizationStore = {
+  status: ConnectionStatus
+  currentIteration: number
+  lastLoss: number | null
+  gradientNorm: number | null
+  topology: string | null
+  lossHistory: number[]
+  gradientHistory: number[]
+  lastMessageAt: number | null
+  lastIteration: IterationMetrics | null
+  convergence: ConvergenceMessage | null
+  violations: ConstraintViolationMessage[]
+  solverWS: SolverWS | null
+  startOptimization: (params: OptParams) => Promise<void>
+  pauseOptimization: () => void
+  onIterationUpdate: (cb: (d: IterationMetrics) => void) => () => void
+}
+
+function toIterationMetrics(data: IterationMessage, fallbackIter: number): IterationMetrics {
+  return {
+    iter: data.iter ?? fallbackIter,
+    loss: data.loss,
+    gradNorm: data.gradNorm,
+    topology: data.topology,
+    timestamp: data.timestamp ?? Date.now(),
+    metrics: data.metrics
+  }
+}
+
+function handleTopologySwitch(data: TopologySwitchMessage | undefined, current: string | null) {
+  if (!data) return current
+  return data.to ?? current
+}
+
+export const useOptimization = create<OptimizationStore>((set, get) => ({
+  status: 'idle',
+  currentIteration: 0,
+  lastLoss: null,
+  gradientNorm: null,
+  topology: null,
+  lossHistory: [],
+  gradientHistory: [],
+  lastMessageAt: null,
+  lastIteration: null,
+  convergence: null,
+  violations: [],
+  solverWS: null,
+  onIterationUpdate: (cb) => {
+    iterationListeners.add(cb)
+    return () => iterationListeners.delete(cb)
+  },
+  startOptimization: async (params: OptParams) => {
+    const existing = get().solverWS
+    existing?.close()
+
+    set({
+      currentIteration: 0,
+      lastLoss: null,
+      gradientNorm: null,
+      lossHistory: [],
+      gradientHistory: [],
+      lastIteration: null,
+      topology: null,
+      lastMessageAt: null,
+      convergence: null,
+      violations: []
+    })
+
+    const url = import.meta.env.VITE_SOLVER_WS_URL || 'ws://localhost:8787/ws'
+    const ws = new SolverWS(url, {
+      onIteration: (data) => {
+        const iterMetrics = toIterationMetrics(data, get().currentIteration + 1)
+        iterationListeners.forEach((listener) => listener(iterMetrics))
+        set((state) => ({
+          currentIteration: iterMetrics.iter,
+          lastLoss: iterMetrics.loss ?? state.lastLoss,
+          gradientNorm: iterMetrics.gradNorm ?? state.gradientNorm,
+          topology: iterMetrics.topology ?? state.topology,
+          lossHistory: clampHistory(state.lossHistory, iterMetrics.loss),
+          gradientHistory: clampHistory(state.gradientHistory, iterMetrics.gradNorm),
+          lastMessageAt: iterMetrics.timestamp,
+          lastIteration: iterMetrics
+        }))
+      },
+      onTopology: (data) => {
+        set((state) => ({ topology: handleTopologySwitch(data, state.topology) }))
+      },
+      onConvergence: (data) => {
+        set({ convergence: data })
+      },
+      onViolation: (data) => {
+        set((state) => ({ violations: [...state.violations, data] }))
+      },
+      onStatusChange: (status) => set({ status })
+    })
+
+    ws.connect()
+
+    set({ solverWS: ws, status: ws.connectionStatus })
+
+    try {
+      await fetch((import.meta.env.VITE_API_BASE ?? '/api') + '/opt/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(params)
+      })
+    } catch (error) {
+      console.warn('Failed to notify optimizer start', error)
+    }
+  },
+  pauseOptimization: () => {
+    const ws = get().solverWS
+    ws?.close()
+    set({ solverWS: null, status: 'closed' })
+  }
+}))

--- a/packages/web-ui/src/styles.css
+++ b/packages/web-ui/src/styles.css
@@ -1,0 +1,170 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #020617;
+}
+
+html, body, #root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: radial-gradient(circle at top, rgba(30, 64, 175, 0.35), transparent 45%), #020617;
+  color: #f8fafc;
+}
+
+canvas {
+  outline: none;
+}
+
+.app-shell {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.app-loading {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  font-size: 1.25rem;
+  letter-spacing: 0.08em;
+}
+
+.hud {
+  position: absolute;
+  top: 1.5rem;
+  left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  width: min(22rem, calc(100% - 3rem));
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.9rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(14px);
+}
+
+.hud header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.hud__status {
+  color: #38bdf8;
+}
+
+.hud__badge {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  background: rgba(59, 130, 246, 0.25);
+  color: #bfdbfe;
+}
+
+.hud__badge--good {
+  background: rgba(34, 197, 94, 0.2);
+  color: #bbf7d0;
+}
+
+.hud__badge--progress {
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.75; }
+  50% { opacity: 1; }
+}
+
+.hud__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(6.5rem, 1fr));
+  gap: 0.75rem;
+}
+
+.hud__label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  color: #64748b;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.2rem;
+}
+
+.hud__value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.hud__muted {
+  margin-top: 0.2rem;
+  font-size: 0.7rem;
+  color: #94a3b8;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hud__spark {
+  display: flex;
+  justify-content: flex-end;
+  opacity: 0.85;
+}
+
+.hud__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.hud__button {
+  flex: 1;
+  appearance: none;
+  border: none;
+  border-radius: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  background: linear-gradient(135deg, #2563eb, #22d3ee);
+  color: #0f172a;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.hud__button:hover:enabled {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(56, 189, 248, 0.25);
+}
+
+.hud__button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.4);
+  opacity: 0.7;
+}
+
+.hud__button--secondary {
+  background: rgba(15, 23, 42, 0.6);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+@media (max-width: 768px) {
+  .hud {
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(24rem, calc(100% - 2rem));
+  }
+
+  .hud__row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/packages/web-ui/src/types/index.ts
+++ b/packages/web-ui/src/types/index.ts
@@ -1,0 +1,22 @@
+export type MeshData = {
+  vertices: Float32Array
+  indices: Uint32Array
+}
+
+export type AcousticNode = {
+  x: number
+  y: number
+  z: number
+  amp: number
+}
+
+export type IterationMetrics = {
+  iter: number
+  loss?: number
+  gradNorm?: number
+  topology?: string
+  timestamp?: number
+  metrics?: Record<string, number>
+}
+
+export type OptParams = Record<string, number>

--- a/packages/web-ui/tsconfig.json
+++ b/packages/web-ui/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "vite-env.d.ts"]
+}

--- a/packages/web-ui/vite-env.d.ts
+++ b/packages/web-ui/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/web-ui/vite.config.ts
+++ b/packages/web-ui/vite.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, loadEnv } from 'vite'
+import react from '@vitejs/plugin-react-swc'
+import path from 'node:path'
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@core': path.resolve(__dirname, 'src/core'),
+        '@components': path.resolve(__dirname, 'src/components'),
+        '@stores': path.resolve(__dirname, 'src/stores'),
+        '@lib': path.resolve(__dirname, 'src/lib'),
+        '@types': path.resolve(__dirname, 'src/types')
+      }
+    },
+    server: {
+      port: 5173,
+      host: true,
+      proxy: {
+        '/api': {
+          target: env.VITE_API_PROXY ?? 'http://localhost:8787',
+          changeOrigin: true
+        }
+      }
+    },
+    build: {
+      sourcemap: true,
+      target: 'es2020'
+    }
+  }
+})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bagger-spl"
+version = "0.1.0"
+description = "Core simulation and gateway scaffolding for the Bagger-SPL platform"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[tool.setuptools]
+package-dir = {"" = "python"}
+
+[tool.setuptools.packages.find]
+where = ["python"]

--- a/python/spl_core/__init__.py
+++ b/python/spl_core/__init__.py
@@ -1,0 +1,11 @@
+"""Public interface for the Bagger-SPL simulation core."""
+
+from .drivers import DriverParameters, BoxDesign
+from .acoustics.sealed import SealedBoxSolver, SealedBoxResponse
+
+__all__ = [
+    "DriverParameters",
+    "BoxDesign",
+    "SealedBoxSolver",
+    "SealedBoxResponse",
+]

--- a/python/spl_core/acoustics/__init__.py
+++ b/python/spl_core/acoustics/__init__.py
@@ -1,0 +1,5 @@
+"""Acoustic solver implementations."""
+
+from .sealed import SealedBoxSolver, SealedBoxResponse
+
+__all__ = ["SealedBoxSolver", "SealedBoxResponse"]

--- a/python/spl_core/acoustics/sealed.py
+++ b/python/spl_core/acoustics/sealed.py
@@ -1,0 +1,94 @@
+"""Simplified sealed-box acoustic solver.
+
+This module intentionally focuses on analytical formulations that run without
+third-party numerical dependencies. The implementation provides a physics-
+grounded baseline that we can extend with higher fidelity models (modal
+extensions, non-linear suspension) in later milestones.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import log10, pi, sqrt
+from typing import Iterable, List
+
+from ..drivers import AIR_DENSITY, BoxDesign, DriverParameters
+
+P_REF = 20e-6  # 20 µPa reference pressure for SPL
+
+
+@dataclass(slots=True)
+class SealedBoxResponse:
+    """Frequency-domain response of a sealed-box system."""
+
+    frequency_hz: List[float]
+    spl_db: List[float]
+    impedance_ohm: List[complex]
+    cone_velocity_ms: List[float]
+
+
+class SealedBoxSolver:
+    """Analytical solver for classic sealed enclosures."""
+
+    def __init__(self, driver: DriverParameters, box: BoxDesign, drive_voltage: float = 2.83):
+        self.driver = driver
+        self.box = box
+        self.drive_voltage = drive_voltage
+
+        self._cms = driver.compliance()
+        self._cab = box.air_compliance(driver)
+        self._cms_total = 1.0 / (1.0 / self._cms + 1.0 / self._cab)
+
+        self._w_s = 2 * pi * driver.fs_hz
+        self._qes = driver.qes()
+        self._qms = driver.qms()
+        self._rms = driver.mechanical_resistance()
+
+    def system_resonance(self) -> float:
+        """Return the resonance frequency (Fc) of the boxed system."""
+
+        return 1.0 / (2 * pi * sqrt(self.driver.mms_kg * self._cms_total))
+
+    def system_qtc(self) -> float:
+        """Return total system Q including electrical damping."""
+
+        qes_box = self._qes * (self._cms / self._cms_total)
+        inv_qtc = 1.0 / self._qms + 1.0 / qes_box
+        return 1.0 / inv_qtc
+
+    def frequency_response(self, frequencies_hz: Iterable[float], mic_distance_m: float = 1.0) -> SealedBoxResponse:
+        """Compute SPL/impedance over the requested frequencies."""
+
+        freq_list: List[float] = []
+        spl_list: List[float] = []
+        imp_list: List[complex] = []
+        vel_list: List[float] = []
+
+        cms_total = self._cms_total
+        driver = self.driver
+
+        for f in frequencies_hz:
+            if f <= 0:
+                continue
+            omega = 2 * pi * f
+
+            # Mechanical impedance of the moving system + box air load
+            zm = self._rms + 1j * (omega * driver.mms_kg - 1.0 / (omega * cms_total))
+
+            # Total electrical impedance seen by the amplifier
+            ze = driver.re_ohm + 1j * omega * driver.le_h + (driver.bl_t_m**2) / zm
+
+            current = self.drive_voltage / ze
+            force = driver.bl_t_m * current
+            velocity = force / zm
+            volume_velocity = velocity * driver.sd_m2
+
+            pressure = omega * AIR_DENSITY * abs(volume_velocity) / (2 * pi * mic_distance_m)
+            spl = 20.0 * log10(max(pressure / P_REF, 1e-12))
+
+            freq_list.append(f)
+            spl_list.append(spl)
+            imp_list.append(ze)
+            vel_list.append(abs(velocity))
+
+        return SealedBoxResponse(freq_list, spl_list, imp_list, vel_list)

--- a/python/spl_core/drivers.py
+++ b/python/spl_core/drivers.py
@@ -1,0 +1,95 @@
+"""Driver and enclosure data models used across the simulation core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import pi
+
+AIR_DENSITY = 1.2041  # kg/m^3 at 20°C
+SPEED_OF_SOUND = 343.0  # m/s at 20°C
+
+
+@dataclass(slots=True)
+class DriverParameters:
+    """Minimal Thiele/Small parameter set for low-frequency simulations."""
+
+    fs_hz: float
+    """Free-air resonance frequency (Hz)."""
+
+    qts: float
+    """Total Q at fs (dimensionless)."""
+
+    re_ohm: float
+    """DC resistance of the voice coil (ohms)."""
+
+    bl_t_m: float
+    """Force factor (Tesla-metres)."""
+
+    mms_kg: float
+    """Moving mass including air load (kilograms)."""
+
+    sd_m2: float
+    """Effective piston area (square metres)."""
+
+    le_h: float = 0.0007
+    """Voice-coil inductance (Henries)."""
+
+    vas_l: float | None = None
+    """Equivalent compliance volume (litres). Optional if Cms derived from fs/mms."""
+
+    def vas_m3(self) -> float:
+        """Return the compliance volume in cubic metres."""
+
+        if self.vas_l is not None:
+            return self.vas_l / 1000.0
+        return self.compliance() * AIR_DENSITY * SPEED_OF_SOUND**2 * self.sd_m2**2
+
+    def compliance(self) -> float:
+        """Return the mechanical compliance Cms (m/N)."""
+
+        return 1.0 / ((2 * pi * self.fs_hz) ** 2 * self.mms_kg)
+
+    def qes(self) -> float:
+        """Electrical Q derived from BL, Re, and moving mass."""
+
+        w_s = 2 * pi * self.fs_hz
+        return (w_s * self.mms_kg * self.re_ohm) / (self.bl_t_m**2)
+
+    def qms(self) -> float:
+        """Mechanical Q derived from Qts and Qes."""
+
+        qes = self.qes()
+        if qes <= 0:
+            raise ValueError("Qes must be positive")
+        inv_qms = 1.0 / self.qts - 1.0 / qes
+        if inv_qms <= 0:
+            # fall back to lightly damped assumption
+            inv_qms = 1.0 / (self.qts * 1.2)
+        return 1.0 / inv_qms
+
+    def mechanical_resistance(self) -> float:
+        """Return Rms (mechanical losses) in N·s/m."""
+
+        w_s = 2 * pi * self.fs_hz
+        return (w_s * self.mms_kg) / self.qms()
+
+
+@dataclass(slots=True)
+class BoxDesign:
+    """Parameters describing a sealed enclosure."""
+
+    volume_l: float
+    """Net internal volume (litres)."""
+
+    leakage_q: float = 15.0
+    """Optional leakage quality factor (larger => lower leakage)."""
+
+    def volume_m3(self) -> float:
+        """Return enclosure volume in cubic metres."""
+
+        return self.volume_l / 1000.0
+
+    def air_compliance(self, driver: DriverParameters) -> float:
+        """Return Cab, the acoustic compliance of the enclosed air."""
+
+        return self.volume_m3() / (AIR_DENSITY * SPEED_OF_SOUND**2 * driver.sd_m2**2)

--- a/python/tests/test_sealed_box.py
+++ b/python/tests/test_sealed_box.py
@@ -1,0 +1,55 @@
+import math
+import pathlib
+import sys
+import unittest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from spl_core import BoxDesign, DriverParameters, SealedBoxSolver
+
+
+class SealedBoxSolverTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.driver = DriverParameters(
+            fs_hz=37.2,
+            qts=0.38,
+            re_ohm=5.6,
+            bl_t_m=17.0,
+            mms_kg=0.118,
+            sd_m2=0.0855,
+            le_h=0.0007,
+            vas_l=92.0,
+        )
+        self.box = BoxDesign(volume_l=50.0)
+        self.solver = SealedBoxSolver(self.driver, self.box)
+
+    def test_alignment_estimates(self) -> None:
+        fc = self.solver.system_resonance()
+        qtc = self.solver.system_qtc()
+        self.assertGreater(fc, self.driver.fs_hz)
+        self.assertTrue(50.0 < fc < 90.0)
+        self.assertTrue(0.5 < qtc < 1.2)
+
+    def test_frequency_response_shape(self) -> None:
+        fc = self.solver.system_resonance()
+        freqs = [fc / 2, fc, fc * 2]
+        response = self.solver.frequency_response(freqs)
+
+        self.assertEqual(len(response.frequency_hz), len(freqs))
+        self.assertEqual(len(response.spl_db), len(freqs))
+        self.assertEqual(len(response.impedance_ohm), len(freqs))
+
+        spl_low, spl_mid, spl_high = response.spl_db
+        self.assertGreater(spl_mid, spl_low)
+        self.assertGreater(spl_high, spl_mid)
+
+        v_low, v_mid, v_high = response.cone_velocity_ms
+        self.assertGreater(v_mid, v_low)
+        self.assertLess(v_high, v_mid)
+
+        z_mag = abs(response.impedance_ohm[1])
+        self.assertGreater(z_mag, self.driver.re_ohm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/gateway/app/__init__.py
+++ b/services/gateway/app/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI gateway package."""

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -1,0 +1,86 @@
+"""Minimal FastAPI gateway exposing the sealed-box solver."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+try:  # pragma: no cover - FastAPI is optional for the unit test sweep
+    from fastapi import FastAPI
+    from pydantic import BaseModel, Field
+except ImportError:  # pragma: no cover
+    FastAPI = None  # type: ignore
+    BaseModel = object  # type: ignore
+    Field = lambda *_, **__: None  # type: ignore
+
+from spl_core import BoxDesign, DriverParameters, SealedBoxSolver
+
+
+class DriverPayload(BaseModel):  # type: ignore[misc]
+    fs_hz: float = Field(..., gt=0)
+    qts: float = Field(..., gt=0)
+    vas_l: float = Field(..., gt=0)
+    re_ohm: float = Field(..., gt=0)
+    bl_t_m: float = Field(..., gt=0)
+    mms_kg: float = Field(..., gt=0)
+    sd_m2: float = Field(..., gt=0)
+    le_h: float = Field(0.0007, ge=0)
+
+    def to_driver(self) -> DriverParameters:
+        data: Dict[str, float]
+        if hasattr(self, "model_dump"):
+            data = self.model_dump()  # type: ignore[assignment]
+        else:  # pragma: no cover - fallback for type checkers
+            data = dict(self.__dict__)
+        return DriverParameters(**data)  # type: ignore[arg-type]
+
+
+class BoxPayload(BaseModel):  # type: ignore[misc]
+    volume_l: float = Field(..., gt=0)
+    leakage_q: float = Field(15.0, gt=0)
+
+    def to_box(self) -> BoxDesign:
+        data: Dict[str, float]
+        if hasattr(self, "model_dump"):
+            data = self.model_dump()  # type: ignore[assignment]
+        else:  # pragma: no cover
+            data = dict(self.__dict__)
+        return BoxDesign(**data)  # type: ignore[arg-type]
+
+
+class SealedRequest(BaseModel):  # type: ignore[misc]
+    driver: DriverPayload
+    box: BoxPayload
+    frequencies_hz: List[float] = Field(..., min_items=1)
+    mic_distance_m: float = Field(1.0, gt=0)
+    drive_voltage: float = Field(2.83, gt=0)
+
+
+if FastAPI is not None:  # pragma: no branch
+    app = FastAPI(title="Bagger-SPL Gateway", version="0.1.0")
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/simulate/sealed")
+    async def simulate_sealed(payload: SealedRequest) -> dict[str, List[float]]:
+        solver = SealedBoxSolver(
+            payload.driver.to_driver(),
+            payload.box.to_box(),
+            drive_voltage=payload.drive_voltage,
+        )
+        response = solver.frequency_response(payload.frequencies_hz, payload.mic_distance_m)
+        return {
+            "frequency_hz": response.frequency_hz,
+            "spl_db": response.spl_db,
+            "impedance_real": [float(z.real) for z in response.impedance_ohm],
+            "impedance_imag": [float(z.imag) for z in response.impedance_ohm],
+            "cone_velocity_ms": response.cone_velocity_ms,
+            "fc_hz": solver.system_resonance(),
+            "qtc": solver.system_qtc(),
+        }
+else:  # pragma: no cover
+    app = None  # type: ignore
+
+
+__all__ = ["app", "SealedRequest", "DriverPayload", "BoxPayload"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@core/*": ["packages/web-ui/src/core/*"],
+      "@components/*": ["packages/web-ui/src/components/*"],
+      "@stores/*": ["packages/web-ui/src/stores/*"],
+      "@lib/*": ["packages/web-ui/src/lib/*"],
+      "@types/*": ["packages/web-ui/src/types/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document the end-to-end delivery roadmap in docs/delivery-plan.md and surface the new Python simulation core in the README and architecture plan
- introduce a pyproject-backed spl_core package with driver models, a sealed-box analytical solver, and accompanying unit tests
- stub a FastAPI gateway entrypoint that wraps the solver for future REST/WebSocket integration work

## Testing
- python -m unittest discover -s python/tests

------
https://chatgpt.com/codex/tasks/task_e_68c9c0a11b708323a218cd804d5e5011