### PR TITLE
Add optimisation run persistence and gateway tasking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+node_modules/
+dist/
+build/
+.pnpm-store/
+.venv/
+__pycache__/
+.pytest_cache/
+.vscode/
+.DS_Store
+.env
+.env.*
+.cache/
+coverage/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
-# clode
+# Bagger-SPL
+
+A focused loudspeaker enclosure co-design platform blending physics-based simulation, optimization, and modern developer tooling.
+
+## Repository Status
+- ✅ Architecture blueprint captured in [`docs/architecture.md`](docs/architecture.md)
+- ✅ Delivery roadmap captured in [`docs/delivery-plan.md`](docs/delivery-plan.md)
+- ✅ Frontend + mock backend scaffolding bootstrapped with pnpm workspaces
+- ✅ Solver telemetry HUD with typed WebSocket protocol + GPU.js pressure renderer
+- ✅ Analytical sealed + vented-box solvers with FastAPI endpoints (see [`spl_core`](python/spl_core) and [`services/gateway`](services/gateway))
+- ✅ Alignment summary metrics (-3 dB bandwidth, velocity peaks) exposed alongside solver responses
+- ✅ Suspension compliance curve helper and excursion headroom metrics for sealed + vented solvers
+- ✅ JSON schema exports for solver request/response contracts (see [`spl_core/serialization.py`](python/spl_core/serialization.py))
+- ✅ Python linting and type-checking automation wired into the pnpm workspace scripts
+- ✅ FastAPI optimisation run API with SQLite-backed persistence and background solver tasks
+- 🛠️ Extended FastAPI gateway, optimisation stack, and FEM/BEM solvers under development
+
+## Prerequisites
+- Node.js 20+
+- pnpm 9+
+- (optional) Python 3.11+ for upcoming gateway/simulation services
+
+## Getting Started
+1. Install dependencies
+   ```bash
+   pnpm install
+   ```
+2. (Optional) Install Python dev dependencies for lint/type/test workflows
+   ```bash
+   pip install -e .[dev]
+   ```
+3. In one terminal start the mock backend & WebSocket feed (includes the optimisation run API)
+   ```bash
+   pnpm --filter @motosub/dev-mocks dev
+   ```
+4. In another terminal launch the Studio web client
+   ```bash
+   pnpm --filter @motosub/web-ui dev
+   ```
+5. Open http://localhost:5173 to view the demo enclosure renderer streaming synthetic optimization telemetry.
+   The optimisation HUD now records backend runs via `/api/opt/start` and polls `/api/opt/{id}` for convergence data.
+
+## Quality checks
+
+Run the consolidated automation from the repo root:
+
+```bash
+pnpm lint        # eslint for the web workspace + ruff for python modules
+pnpm typecheck   # tsconfig builds + mypy over python/services
+pnpm py:test     # Python unit tests
+```
+
+## Workspace Layout
+```
+packages/
+  web-ui/      # Vite + React Three Fiber Studio shell + live optimization HUD
+  dev-mocks/   # Mock API + typed WebSocket server for local development
+```
+
+Additional services (gateway, simulation core, CLI) will be added following the blueprint in `docs/architecture.md`.
+
+## Next Steps
+- Grow the Python simulation core beyond first-order alignments (excursion limits, tolerance analysis)
+- Promote the FastAPI gateway stub into a production-ready service with persistence and WebSocket telemetry
+- Expand the Studio telemetry panels (SPL, impedance, excursion headroom overlays)
+- Wire Playwright/Vitest automation once backend contracts stabilize
+
+## Python Simulation Core
+
+The analytical sealed- and vented-box solvers live in the [`spl_core`](python/spl_core) package
+and are exposed via a lightweight FastAPI gateway stub in
+[`services/gateway`](services/gateway). Run the Python unit tests with:
+
+```bash
+python -m unittest discover -s python/tests
+```
+
+Contributions and feedback are welcome as we grow Bagger-SPL toward an offline-first yet cloud-capable toolchain.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,114 @@
+# Bagger-SPL Platform Architecture (v1)
+
+## 1. Vision & Objectives
+- Deliver production-ready bass enclosure co-design combining loudspeaker physics with user-friendly workflows.
+- Prioritize maintainability and incremental delivery over speculative scope while preserving extensibility for advanced research features.
+- Ensure every service can run on a single developer workstation first, then scale out to optional cloud accelerators.
+
+## 2. Guiding Design Principles
+1. **Single source of truth for physics** – a well-tested core simulation/optimization library that both the CLI and UI consume.
+2. **Incremental fidelity** – start with analytical + reduced-order models, progressively unlock FEM/BEM refinements when hardware is available.
+3. **Observable by default** – instrument solvers and services with structured logs and metrics from day one.
+4. **Offline-first** – every workflow must run with bundled datasets and simplified solvers without network access.
+5. **Composable interfaces** – prefer gRPC/JSON schemas and typed client SDKs to glue components together with minimal duplication.
+
+## 3. System Overview
+```
++----------------+        +-------------------+        +-----------------+
+|  Studio (Web)  | <--->  |  Design Gateway   | <----> |  Simulation Core |
+|  & CLI (Node)  |        |  (FastAPI + WS)   |        |  (Python/NumPy)  |
++----------------+        +-------------------+        +-----------------+
+         |                         |                             |
+         v                         v                             v
+  Local Cache (TS)      Artifact Store (SQLite)        Optional GPU kernels
+         |                         |                             |
+         +-------------------> Telemetry Sink <------------------+
+```
+- **Studio UI**: Vite/React canvas for topology visualization, solver control, and result dashboards.
+- **CLI**: Node-based automation front end sharing the same SDK as the UI for parity and scripting.
+- **Design Gateway**: FastAPI app exposing REST + WebSocket endpoints, orchestrating solver jobs, handling caching, and publishing progress events.
+- **Simulation Core**: Python package encapsulating loudspeaker models, reduced-order acoustic solvers, and multi-resolution optimizers with optional GPU acceleration (CuPy) when available.
+- **Local Cache & Artifact Store**: SQLite + msgpack bundles storing driver data, run histories, and exported geometries to support offline usage.
+- **Telemetry Sink**: Structured logs + metrics (OpenTelemetry/Prometheus) enabling performance tracking even in single-node mode.
+
+## 4. Component Breakdown
+
+### 4.1 Core Physics Library (`python/spl_core`)
+- **Modules**:
+  - `drivers`: TS parameter ingestion, validation, interpolation (kNN + GP-lite) plus suspension compliance curve synthesis and excursion utilities.
+  - `mechanics`: Suspension/BL curve estimators with physics-informed regularization (progressively migrating out of `drivers`).
+  - `acoustics`: Reduced-order box/port solver (sealed + vented alignments landed with excursion headroom metrics, modal extensions queued) with hooks for FEM/BEM adapters.
+  - `optimization`: Multi-resolution optimizer (differential evolution ➜ L-BFGS) with constraint ledger.
+  - `validation`: Monte Carlo tolerance analysis and reciprocity/thermal sanity checks.
+  - `serialization`: JSON schema exports for solver requests/responses used by gateway + clients.
+- **API Surface**: Plain Python classes exported through pydantic models; zero global state.
+
+### 4.2 Simulation Gateway (`services/gateway`)
+- FastAPI app that:
+  - Exposes REST endpoints for job submission, driver queries, exports.
+  - Returns alignment summaries (Fc/Qtc, Fb, -3 dB edges, velocity peaks) alongside solver traces.
+  - Hosts WebSocket streams for live optimization telemetry (iterations, constraint hits, topology swaps).
+  - Manages run lifecycle (start, pause, resume, cancel) with async tasks.
+  - Persists run inputs/outputs in SQLite using SQLModel.
+  - Uses dependency-injected `spl_core` instances for testability.
+
+### 4.3 Client SDK (`packages/sdk`)
+- Generated TypeScript + Python clients sharing OpenAPI schema.
+- Provides strongly-typed calls, WebSocket helpers with auto-reconnect, and offline fallbacks.
+
+### 4.4 Studio Web App (`apps/studio`)
+- Vite + React + Zustand for state management.
+- Three.js-based enclosure viewer fed by gateway mesh snapshots.
+- Uses TanStack Query for API calls, Msgpack WebSocket stream for telemetry.
+- Pluggable data panels (SPL curve, impedance, constraint ledger).
+
+### 4.5 CLI (`apps/cli`)
+- Node-based CLI (ts-node / bun) bundling the SDK.
+- Commands: `init`, `optimize`, `export`, `validate`, `cache sync`.
+- Shares configuration with Studio via `.bagger/config.yaml`.
+
+### 4.6 Tooling & Infrastructure
+- **Data packages**: `data/driver-db.msgpack`, `data/topologies/*.json` shipped with installer.
+- **Testing**: Pytest for `spl_core`, Vitest/Playwright for Studio, smoke tests for CLI.
+- **Build**: `uv` for Python deps, `pnpm` workspaces for JS/TS; `make` orchestrates.
+- **Packaging**: Docker images optional; primary distribution is Python wheel + npm packages to keep onboarding light.
+- **Observability**: Structured logging (loguru), metrics via `prometheus-client`, OpenTelemetry export toggled by env var.
+
+## 5. Deployment Modes
+1. **Solo Developer** (default)
+   - FastAPI gateway + simulation core run locally.
+   - SQLite + local cache only.
+   - Studio served via `pnpm dev` proxying to FastAPI.
+2. **Team Server** (optional)
+   - Docker Compose: gateway, Redis for job queue, Postgres for shared artifacts, Traefik proxy.
+   - GPU workers registered through simple heartbeat service.
+3. **Cloud Burst** (future)
+   - Reuse same FastAPI container with autoscaling compute pods.
+   - Feature flag to offload heavy simulations to GPU nodes.
+
+## 6. Incremental Delivery Plan
+| Milestone | Scope | Key Deliverables |
+|-----------|-------|------------------|
+| M1 – Foundations | Establish repo layout, scaffolding, driver dataset ingestion, sealed-box solver, CLI `optimize` command. | Working FastAPI gateway, Studio skeleton showing SPL curve, automated tests + CI. |
+| M2 – Optimization Loop | Implement multi-resolution optimizer, telemetry streaming, topology visualizer, tolerance analysis. | End-to-end run on bundled dataset with convergence dashboard. |
+| M3 – Advanced Fidelity | Introduce ported enclosures, thermal model hooks, GPU acceleration toggle, artifact exports (DXF/STL). | Extended analytics, offline caching improvements. |
+| M4 – Integration & Hardening | Add Monte Carlo validation, measurement feedback importer, packaging/installers, observability dashboards. | Release candidate for v1.0. |
+
+## 7. Technology Summary
+- **Languages**: Python 3.11+, TypeScript 5+
+- **Frontend**: Vite, React 18, Three.js, Zustand, TanStack Query, ECharts (for plots)
+- **Backend**: FastAPI, SQLModel/SQLite, Uvicorn, Redis (optional)
+- **Simulation**: NumPy/SciPy, CuPy (optional), scikit-learn-lite (e.g., `umap-learn`), custom optimization routines.
+- **Transport**: REST (JSON) for control plane, Msgpack over WebSocket for telemetry.
+- **Build/Test**: pnpm, uv, pytest, Ruff, mypy, Vitest, Playwright, GitHub Actions CI.
+- **Packaging**: Python wheels via `uv build`, npm packages, optional Docker Compose definitions.
+
+## 8. Next Steps Toward Development
+1. ✅ Scaffold initial repository structure with `packages/web-ui` and `packages/dev-mocks`; continue fleshing out apps, services, python libs, and data.
+2. ✅ Land initial FastAPI gateway stub backed by the analytical sealed-box solver housed in `spl_core`.
+3. ✅ Provide unit tests validating sealed-box alignment (Fc/Qtc, SPL/impedance shape).
+4. Define shared configuration schema (`bagger.config.jsonschema`) and auto-generate TS/Python types.
+5. Wire Studio SPL plot + WebSocket telemetry using mocked backend.
+6. Set up CI pipeline executing lint/type/test on both Python and TypeScript stacks.
+
+This architecture keeps the platform approachable for a small team while preserving clear pathways to high-fidelity simulation and cloud-scale deployments when needed.

--- a/docs/delivery-plan.md
+++ b/docs/delivery-plan.md
@@ -1,0 +1,139 @@
+# Bagger-SPL Delivery Plan (v0.2)
+
+This document consolidates the multi-LLM build proposal into an actionable
+roadmap for the Bagger-SPL platform. It aligns the architecture blueprint with
+concrete implementation workstreams so the team can execute incrementally while
+preserving the long-term vision.
+
+## 1. Program Pillars
+
+1. **Large-signal interpolation engine** – Dual-stage manifold → Gaussian
+   Process stack for synthesising driver behaviour with physics regularisation
+   (monotonic BL, symmetric Kms, causal inductance, and thermal modelling).
+2. **Hybrid acoustic solver core** – Coupled FEM/BEM formulation with
+   GMRES-based Helmholtz solver, nonlinear extensions (port compression,
+   suspension creep, thermal coupling, cone breakup), and optional transient
+   simulation.
+3. **Convergence acceleration** – Multi-resolution optimisation ladder
+   (differential evolution → adjoint trust-region → interior-point) with
+   manufacturing constraints and telemetry hooks.
+4. **Validation loop** – Measurement ingestion (Klippel/REW), Bayesian model
+   updating, tolerance stack Monte Carlo, and systematic error correction.
+5. **Advanced topologies** – Metamaterial resonators and hybrid active/passive
+   cancellation modules as opt-in enhancements beyond the core sealed/ported
+   families.
+6. **Cloud & offline runtime** – Distributed compute (AWS/GCP), caching, and
+   full offline subset with simplified solver for field deployments.
+7. **Safety and performance** – Thermal/structural guardrails, vibration
+   survivability checks, and benchmark dashboards tracking SPL error,
+   optimisation throughput, and resource usage.
+
+## 2. Workstream Breakdown
+
+### 2.1 ML Driver Synthesiser
+- Implement UMAP+kNN coarse search followed by physics-informed Gaussian
+  Processes per curve (BL, Kms, Le, thermal network).
+- Enforce regularisers (monotonicity, symmetry, causality) and reciprocity
+  projection.
+- Deliver evaluation harness targeting the stated RMSE goals for SPL, THD, and
+  compression across the holdout dataset.
+
+### 2.2 Acoustic Solver Core
+- Establish the FEM interior / FMM-BEM exterior coupling with PML boundaries
+  and mortar interface constraints.
+- Provide steady-state Helmholtz solve via GMRES + physics preconditioner and
+  transient Newmark-β integrator with adaptive timestep.
+- Layer in nonlinearities: port compression, suspension creep, thermal-acoustic
+  coupling, cone breakup modal overlay.
+
+### 2.3 Optimisation System
+- Realise the multi-resolution workflow (coarse differential evolution,
+  medium trust-region adjoint, fine interior-point) with constraint ledger from
+  manufacturing rules.
+- Capture convergence history, gradient norms, and topology switches for UI and
+  analytics consumers.
+
+### 2.4 Validation & Feedback
+- Build measurement ingestion for Klippel `.dat` and REW `.mdat` files,
+  producing delta fields (SPL, phase, impedance, THD).
+- Apply Bayesian updating to adjust solver priors; flag systematic errors and
+  derive correction factors (port end correction, damping multipliers, etc.).
+- Encode production tolerances (material thickness, cutting precision, driver
+  variation) and support Monte Carlo runs with 95% confidence reporting.
+
+### 2.5 Advanced Topology Modules
+- Metamaterial resonator designer for embedding Helmholtz arrays.
+- Hybrid active cancellation module to place small drivers at pressure nodes
+  with IIR filter synthesis.
+
+### 2.6 Runtime & Infrastructure
+- Docker Compose + Kubernetes manifests for production deployment (nginx,
+  gateway, solver workers, Postgres, Redis, Prometheus, Grafana).
+- Offline cache bundle for common drivers/topologies with simplified solver and
+  iteration cap.
+
+### 2.7 Safety & Benchmarks
+- Thermal protection heuristics (coil, adhesive, magnet, port heating) with
+  mitigation recommendations.
+- Structural vibration verification using ISO 16750-3 profile and modal stress
+  analysis.
+- Continuous benchmarking dataset capturing SPL/phase error, optimisation time,
+  mesh generation, export latency, and memory footprint.
+
+## 3. Execution Milestones
+
+| Milestone | Target | Key Outcomes |
+|-----------|--------|--------------|
+| **M1 – Foundations** | Month 1 | pnpm/pyproject scaffolding, sealed-box analytical solver (delivered in `spl_core`), FastAPI gateway stub, Studio shell with mock telemetry, unit tests + CI bootstrap. |
+| **M2 – Optimisation Loop** | Month 3 | Differential-evolution coarse search, trust-region refinement, typed WebSocket telemetry, SPL/impedance panels in Studio, measurement ingestion prototype. |
+| **M3 – High-Fidelity Solvers** | Month 6 | FEM/BEM coupling prototype, nonlinear extensions, Monte Carlo tolerance engine, Playwright + pytest integration tests, Docker Compose deployment. |
+| **M4 – Platform Hardening** | Month 9 | Cloud orchestration, offline cache packaging, metamaterial/active modules behind feature flags, observability dashboards, documentation for v1.0 release. |
+
+## Progress Snapshot (Iteration 9)
+
+- **Milestone M1 – Foundations:** 100 % complete. Repository scaffolding, sealed and vented solvers, FastAPI gateway, Studio HUD, consolidated lint/type/test scripts, and excursion reporting are all in place.
+- **Milestone M2 – Optimisation Loop:** ~60 % complete. Telemetry HUD groundwork, solver summaries, compliance curve synthesis, excursion headroom metrics, and the new persisted optimisation run API with background solver tasks wire optimisation state cleanly into the frontend and gateway.
+- **Overall programme:** ≈40 % toward the v1.0 roadmap ((1.0 + 0.6 + 0 + 0) ÷ 4 milestones).
+- Latest iteration introduced the run persistence layer, background task execution, and run-history REST endpoints alongside the existing suspension/excursion instrumentation, unlocking history-aware optimisation flows for downstream services.
+
+## 4. Near-Term Backlog (Next Iterations)
+
+1. **Simulation Core Expansion**
+   - ✅ Extend `spl_core` with vented alignment support exposed via the gateway.
+   - ✅ Add compliance-curve fitting and excursion limit estimation.
+   - ✅ Add JSON schema export for solver inputs/outputs.
+2. **Gateway Evolution**
+   - ✅ Replace optional FastAPI shim with concrete app, including async task
+     manager and SQLite persistence.
+   - Define WebSocket protocol aligning with Studio’s optimisation HUD.
+3. **Studio Integration**
+   - Render SPL/impedance plots from gateway responses.
+   - Surface solver alignment metadata (Fc, Qtc, excursion margins) in HUD.
+4. **Tooling & QA**
+   - ✅ Introduce `ruff` + `mypy` for Python lint/type checks and wire into root
+     `pnpm` scripts.
+   - Author GitHub Actions workflow running JS + Python unit suites.
+
+## 5. Reference Benchmarks & Targets
+
+Current prototype targets retain the previous spec goals:
+
+```
+SPL prediction error   < 0.6 dB (20–200 Hz)
+THD error              < 2.1 % at Xmax / 100 Hz
+Compression error      < 1.8 dB at rated power / 60 s
+Phase error            < 3° (40–140 Hz)
+Optimisation runtime   < 60 s end-to-end
+Mesh generation        < 5 s per refinement step
+Export generation      < 10 s for DXF/STL bundles
+```
+
+The dataset currently tracks 47 validation builds with average SPL error of
+0.9 dB and phase error of 4.1°. Closing the loop with measurement ingestion and
+Bayesian correction is expected to reach the stated launch metrics.
+
+---
+
+This plan provides the connective tissue between the long-form specification
+and the concrete code landing in the repository. Each iteration should update
+this document with progress notes, risk adjustments, and refined targets.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bagger-spl",
+  "private": true,
+  "packageManager": "pnpm@9.0.0",
+  "workspaces": [
+    "packages/web-ui",
+    "packages/dev-mocks"
+  ],
+  "scripts": {
+    "dev": "pnpm -r dev",
+    "build": "pnpm -r build",
+    "lint": "pnpm -r lint && pnpm run py:lint",
+    "typecheck": "pnpm -r typecheck && pnpm run py:typecheck",
+    "py:lint": "python -m ruff check python services",
+    "py:typecheck": "python -m mypy python services",
+    "py:test": "python -m unittest discover -s python/tests"
+  }
+}

--- a/packages/dev-mocks/package.json
+++ b/packages/dev-mocks/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@bagger/dev-mocks",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node ws-mock.js"
+  },
+  "dependencies": {
+    "msgpackr": "^1.12.3",
+    "undici": "^6.19.8",
+    "ws": "^8.18.0"
+  }
+}

--- a/packages/dev-mocks/ws-mock.js
+++ b/packages/dev-mocks/ws-mock.js
@@ -1,0 +1,205 @@
+import http from 'http'
+import { pack } from 'msgpackr'
+import { WebSocketServer } from 'ws'
+
+const runs = new Map()
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(payload))
+}
+
+function buildMockResult(params = {}) {
+  const targetSpl = Number(params.targetSpl ?? 118)
+  const volume = Number(params.maxVolume ?? 60)
+  const history = []
+  let loss = 1.2 + Math.max(0, (targetSpl - 110) / 12)
+  for (let i = 1; i <= 14; i += 1) {
+    loss = Math.max(loss * 0.74, 0.02)
+    history.push({ iter: i, loss, gradNorm: Math.max(loss / (i + 2), 0.01) })
+  }
+  const finalLoss = history[history.length - 1]?.loss ?? 0.02
+  const frequencies = Array.from({ length: 60 }, (_, i) => 20 * Math.pow(200 / 20, i / 59))
+  const spl = frequencies.map((f) => 105 + 8 * Math.exp(-(Math.log(f) - Math.log(55)) ** 2))
+
+  return {
+    history,
+    convergence: {
+      converged: finalLoss < 0.1,
+      finalLoss,
+      iterations: history.length,
+      solution: {
+        spl_peak: Math.max(...spl),
+        fc_hz: 46.5,
+        qtc: 0.68,
+        excursion_headroom_db: 9.8,
+        safe_drive_voltage_v: 7.5
+      }
+    },
+    summary: {
+      fc_hz: 46.5,
+      qtc: 0.68,
+      f3_low_hz: 33.2,
+      f3_high_hz: 210.0,
+      max_spl_db: Math.max(...spl),
+      max_cone_velocity_ms: 0.42,
+      max_cone_displacement_m: 0.008,
+      excursion_ratio: 0.62,
+      excursion_headroom_db: 9.8,
+      safe_drive_voltage_v: 7.5
+    },
+    response: {
+      frequency_hz: frequencies,
+      spl_db: spl,
+      impedance_real: frequencies.map(() => 5 + Math.random()),
+      impedance_imag: frequencies.map(() => Math.sin(Math.random())),
+      cone_velocity_ms: frequencies.map(() => 0.2 + Math.random() * 0.1),
+      cone_displacement_m: frequencies.map(() => 0.002 + Math.random() * 0.001)
+    },
+    metrics: {
+      target_spl_db: targetSpl,
+      achieved_spl_db: Math.max(...spl),
+      volume_l: volume,
+      safe_drive_voltage_v: 7.5
+    }
+  }
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url ?? '/', 'http://localhost')
+
+  if (req.method === 'POST' && url.pathname === '/api/opt/start') {
+    let body = ''
+    req.on('data', (chunk) => { body += chunk })
+    req.on('end', () => {
+      const params = body ? JSON.parse(body) : {}
+      const now = Date.now() / 1000
+      const id = `${now.toString(16)}-${Math.random().toString(16).slice(2, 8)}`
+      const record = {
+        id,
+        status: 'queued',
+        created_at: now,
+        updated_at: now,
+        params,
+        result: null,
+        error: null
+      }
+      runs.set(id, record)
+      sendJson(res, 200, record)
+
+      setTimeout(() => {
+        const running = { ...record, status: 'running', updated_at: Date.now() / 1000 }
+        runs.set(id, running)
+      }, 150)
+
+      setTimeout(() => {
+        const succeeded = {
+          ...runs.get(id),
+          status: 'succeeded',
+          updated_at: Date.now() / 1000,
+          result: buildMockResult(params)
+        }
+        runs.set(id, succeeded)
+      }, 900)
+    })
+    return
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/opt/runs') {
+    const limit = Number(url.searchParams.get('limit') ?? '20')
+    const records = Array.from(runs.values())
+      .sort((a, b) => b.created_at - a.created_at)
+      .slice(0, Math.max(1, limit))
+    sendJson(res, 200, { runs: records })
+    return
+  }
+
+  if (req.method === 'GET' && url.pathname.startsWith('/api/opt/')) {
+    const id = url.pathname.split('/').pop()
+    if (!id) {
+      sendJson(res, 400, { error: 'missing id' })
+      return
+    }
+    const record = runs.get(id)
+    if (!record) {
+      sendJson(res, 404, { error: 'not found' })
+      return
+    }
+    sendJson(res, 200, record)
+    return
+  }
+
+  res.writeHead(200)
+  res.end('OK')
+})
+
+const wss = new WebSocketServer({ noServer: true })
+
+wss.on('connection', (ws) => {
+  let iter = 0
+  const timer = setInterval(() => {
+    iter += 1
+    const message = pack({
+      type: 'ITERATION',
+      data: {
+        iter,
+        loss: Math.exp(-iter / 55),
+        gradNorm: 1 / (iter + 4),
+        topology: iter > 50 ? 'metamaterial' : 'baseline',
+        timestamp: Date.now(),
+        metrics: {
+          spl: 112 + Math.min(iter, 80) * 0.12,
+          spl_peak: 114 + Math.min(iter, 80) * 0.15
+        }
+      }
+    })
+    ws.send(message)
+
+    if (iter === 50) {
+      ws.send(pack({ type: 'TOPOLOGY_SWITCH', from: 'baseline', to: 'metamaterial' }))
+    }
+
+    if (iter % 45 === 0) {
+      ws.send(
+        pack({
+          type: 'CONSTRAINT_VIOLATION',
+          constraint: 'port_velocity',
+          severity: 0.4 + Math.random() * 0.1,
+          location: { section: 'port', index: 2 }
+        })
+      )
+    }
+
+    if (iter === 90) {
+      ws.send(
+        pack({
+          type: 'CONVERGENCE',
+          data: {
+            converged: true,
+            finalLoss: Math.exp(-iter / 55),
+            iterations: iter,
+            cpuTime: 12.4,
+            solution: { volume: 61.2, tuning: 38.5 }
+          }
+        })
+      )
+      clearInterval(timer)
+    }
+  }, 150)
+
+  ws.on('close', () => clearInterval(timer))
+})
+
+server.on('upgrade', (req, socket, head) => {
+  if (req.url === '/ws') {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit('connection', ws, req)
+    })
+  } else {
+    socket.destroy()
+  }
+})
+
+server.listen(8787, () => {
+  console.log('Mock API+WS on http://localhost:8787 (WS at /ws)')
+})

--- a/packages/web-ui/index.html
+++ b/packages/web-ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bagger-SPL Studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@bagger/web-ui",
+  "version": "0.9.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext .ts,.tsx",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@react-three/drei": "^9.114.3",
+    "@react-three/fiber": "^9.0.0-rc.6",
+    "@react-three/postprocessing": "^2.16.1",
+    "@tanstack/react-query": "^5.59.16",
+    "detect-gpu": "^5.0.38",
+    "gpu.js": "^2.16.0",
+    "msgpackr": "^1.12.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "three": "^0.160.0",
+    "valtio": "^1.13.2",
+    "zustand": "^4.5.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react-swc": "^3.7.0",
+    "eslint": "^9.5.0",
+    "eslint-config-next": "^15.0.0-canary.79",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.2"
+  }
+}

--- a/packages/web-ui/src/App.tsx
+++ b/packages/web-ui/src/App.tsx
@@ -1,0 +1,35 @@
+import { Suspense, useMemo } from 'react'
+import { Canvas } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import { EnclosureRenderer } from '@core/EnclosureRenderer'
+import { OptimizationHUD } from '@components/OptimizationHUD'
+import type { MeshData, AcousticNode } from '@types/index'
+
+const demoMesh: MeshData = {
+  vertices: new Float32Array([-0.3, 0, 0, 0.3, 0, 0, 0, 0.5, 0]),
+  indices: new Uint32Array([0, 1, 2])
+}
+
+export default function App() {
+  const nodes: AcousticNode[] = useMemo(
+    () => [
+      { x: 0.2, y: 0.2, z: 0.5, amp: 1.0 },
+      { x: 0.7, y: 0.6, z: 0.5, amp: 0.7 }
+    ],
+    []
+  )
+
+  return (
+    <div className="app-shell">
+      <Suspense fallback={<div className="app-loading">Loading…</div>}>
+        <Canvas camera={{ position: [0.8, 0.6, 1.2], fov: 50 }}>
+          <ambientLight intensity={0.6} />
+          <pointLight position={[3, 3, 3]} />
+          <EnclosureRenderer geometry={demoMesh} acousticNodes={nodes} currentFreq={60} />
+          <OrbitControls makeDefault />
+        </Canvas>
+      </Suspense>
+      <OptimizationHUD />
+    </div>
+  )
+}

--- a/packages/web-ui/src/components/EnclosureMesh.tsx
+++ b/packages/web-ui/src/components/EnclosureMesh.tsx
@@ -1,0 +1,19 @@
+import { useMemo } from 'react'
+import * as THREE from 'three'
+import type { MeshData } from '@types/index'
+
+export function EnclosureMesh({ geometry }: { geometry: MeshData }) {
+  const meshGeometry = useMemo(() => {
+    const g = new THREE.BufferGeometry()
+    g.setAttribute('position', new THREE.BufferAttribute(geometry.vertices, 3))
+    g.setIndex(new THREE.BufferAttribute(geometry.indices, 1))
+    g.computeVertexNormals()
+    return g
+  }, [geometry])
+
+  return (
+    <mesh geometry={meshGeometry}>
+      <meshStandardMaterial metalness={0.1} roughness={0.8} color="#9aa3af" />
+    </mesh>
+  )
+}

--- a/packages/web-ui/src/components/OptimizationHUD.tsx
+++ b/packages/web-ui/src/components/OptimizationHUD.tsx
@@ -1,0 +1,176 @@
+import { useMemo, useState } from 'react'
+import { useOptimization } from '@stores/optimization.store'
+import type { OptParams } from '@types/index'
+import type { ConnectionStatus } from '@lib/websocket'
+
+const DEFAULT_PARAMS: OptParams = {
+  targetSpl: 118,
+  maxVolume: 65,
+  weightLow: 1,
+  weightMid: 0.6
+}
+
+const STATUS_COPY: Record<ConnectionStatus, string> = {
+  idle: 'idle',
+  connecting: 'connecting…',
+  open: 'streaming',
+  reconnecting: 'reconnecting…',
+  closed: 'stopped'
+}
+
+function formatLoss(loss: number | null) {
+  return loss == null ? '—' : loss.toFixed(4)
+}
+
+function formatGradient(grad: number | null) {
+  if (grad == null) return '—'
+  if (grad === 0) return '0'
+  return grad.toExponential(2)
+}
+
+function formatTimestamp(ts: number | null) {
+  if (!ts) return '—'
+  const date = new Date(ts)
+  return `${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}`
+}
+
+export function OptimizationHUD() {
+  const {
+    status,
+    currentIteration,
+    lastLoss,
+    gradientNorm,
+    topology,
+    lossHistory,
+    lastMessageAt,
+    lastIteration,
+    convergence,
+    violations,
+    startOptimization,
+    pauseOptimization
+  } = useOptimization()
+  const [pending, setPending] = useState(false)
+
+  const isActive = status === 'open' || status === 'connecting' || status === 'reconnecting'
+  const hasConverged = (convergence?.converged ?? false) || (gradientNorm != null && gradientNorm < 1e-4 && currentIteration > 0)
+  const iterationCount = convergence?.iterations ?? currentIteration
+  const displayedLoss = convergence?.finalLoss ?? lastLoss
+  const violationCount = violations.length
+  const latestViolation = violations[violationCount - 1]
+
+  const sparklinePath = useMemo(() => {
+    if (lossHistory.length < 2) return ''
+    const width = 120
+    const height = 32
+    const offset = 2
+    const values = lossHistory.slice(-40)
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    const range = max - min || 1
+    return values
+      .map((v, i) => {
+        const x = (i / (values.length - 1)) * (width - offset * 2) + offset
+        const y = height - offset - ((v - min) / range) * (height - offset * 2)
+        return `${x},${y}`
+      })
+      .join(' ')
+  }, [lossHistory])
+
+  const solution = convergence?.solution as Record<string, unknown> | undefined
+  const solutionSpl = typeof solution?.spl === 'number' ? (solution.spl as number) : undefined
+  const solutionSplPeak = typeof solution?.splPeak === 'number' ? (solution.splPeak as number) : undefined
+  const latestSpl = solutionSpl ?? solutionSplPeak ?? lastIteration?.metrics?.spl ?? lastIteration?.metrics?.spl_peak
+  const iterationStamp = formatTimestamp(lastMessageAt)
+
+  const handleStart = async () => {
+    setPending(true)
+    try {
+      await startOptimization(DEFAULT_PARAMS)
+    } catch (error) {
+      console.error('Failed to start optimization session', error)
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <aside className="hud">
+      <header>
+        <span className="hud__status" data-testid="connection-status">
+          {STATUS_COPY[status]}
+        </span>
+        <span className={`hud__badge ${hasConverged ? 'hud__badge--good' : 'hud__badge--progress'}`} data-testid="convergence-indicator">
+          {hasConverged ? 'converged' : isActive ? 'optimizing…' : 'standing by'}
+        </span>
+      </header>
+
+      <div className="hud__row">
+        <div>
+          <div className="hud__label">Iteration</div>
+          <div className="hud__value" data-testid="iteration-count">{iterationCount}</div>
+        </div>
+        <div>
+          <div className="hud__label">Loss</div>
+          <div className="hud__value" data-testid="latest-loss">{formatLoss(displayedLoss)}</div>
+        </div>
+        <div>
+          <div className="hud__label">Gradient</div>
+          <div className="hud__value" data-testid="gradient-norm">{formatGradient(gradientNorm)}</div>
+        </div>
+      </div>
+
+      <div className="hud__row">
+        <div>
+          <div className="hud__label">Topology</div>
+          <div className="hud__value" data-testid="topology-tag">{topology ?? '—'}</div>
+        </div>
+        <div>
+          <div className="hud__label">Last update</div>
+          <div className="hud__value">{iterationStamp}</div>
+        </div>
+        <div>
+          <div className="hud__label">Peak SPL</div>
+          <div className="hud__value" data-testid="final-spl">
+            {latestSpl != null ? latestSpl.toFixed(1) : '—'}
+          </div>
+        </div>
+        <div>
+          <div className="hud__label">Violations</div>
+          <div className="hud__value" data-testid="violation-count">{violationCount}</div>
+          {latestViolation && (
+            <div className="hud__muted">{latestViolation.constraint}{' '}
+              {typeof latestViolation.severity === 'number' ? `• ${(latestViolation.severity * 100).toFixed(0)}%` : ''}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="hud__spark">
+        <svg width="120" height="32" role="img" aria-label="Loss trend">
+          <polyline points={sparklinePath} fill="none" stroke="#22d3ee" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </div>
+
+      <footer className="hud__actions">
+        <button
+          type="button"
+          className="hud__button"
+          data-testid="start-optimization"
+          onClick={handleStart}
+          disabled={pending || isActive}
+        >
+          {pending ? 'Starting…' : 'Start'}
+        </button>
+        <button
+          type="button"
+          className="hud__button hud__button--secondary"
+          data-testid="pause-optimization"
+          onClick={pauseOptimization}
+          disabled={!isActive}
+        >
+          Pause
+        </button>
+      </footer>
+    </aside>
+  )
+}

--- a/packages/web-ui/src/components/PortFlowLines.tsx
+++ b/packages/web-ui/src/components/PortFlowLines.tsx
@@ -1,0 +1,6 @@
+import { Line } from '@react-three/drei'
+
+export function PortFlowLines({ points }: { points?: [number, number, number][] }) {
+  if (!points || points.length < 2) return null
+  return <Line points={points} lineWidth={1} color="#10b981" dashed />
+}

--- a/packages/web-ui/src/components/PressureField.tsx
+++ b/packages/web-ui/src/components/PressureField.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react'
+import * as THREE from 'three'
+import { useFrame } from '@react-three/fiber'
+
+export function PressureField({ data, res }: { data: Float32Array; res: number }) {
+  const texture = useMemo(() => {
+    const normalized = new Float32Array(data.length)
+    let min = Infinity
+    let max = -Infinity
+
+    for (let i = 0; i < data.length; i += 1) {
+      const value = data[i]
+      if (value < min) min = value
+      if (value > max) max = value
+    }
+
+    const range = max - min || 1
+    for (let i = 0; i < data.length; i += 1) {
+      normalized[i] = (data[i] - min) / range
+    }
+
+    const tex = new THREE.DataTexture(normalized, res, res, THREE.RedFormat, THREE.FloatType)
+    tex.needsUpdate = true
+    tex.colorSpace = THREE.LinearSRGBColorSpace
+    return tex
+  }, [data, res])
+
+  useFrame(() => {
+    texture.needsUpdate = true
+  })
+
+  return (
+    <mesh position={[0.5, 0.5, 0.001]}>
+      <planeGeometry args={[1, 1, 1, 1]} />
+      <shaderMaterial uniforms={{ uTex: { value: texture } }} vertexShader={vertexShader} fragmentShader={fragmentShader} transparent />
+    </mesh>
+  )
+}
+
+const vertexShader = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`
+
+const fragmentShader = /* glsl */ `
+  precision highp float;
+  uniform sampler2D uTex;
+  varying vec2 vUv;
+
+  vec3 turbo(float x){
+    return clamp(vec3(
+      34.61 + x*(1172.33 + x*(-10743.0 + x*(33300.0 + x*(-38394.0 + x*15417.0)))) ,
+      23.31 + x*(557.33 + x*(1225.0 + x*(-3574.0 + x*(4107.0 + x*(-1625.0))))) ,
+      27.2 + x*(321.0 + x*(1844.0 + x*(-3544.0 + x*(2752.0 + x*(-780.0)))))
+    )/255.0,0.0,1.0);
+  }
+
+  void main(){
+    float v = texture2D(uTex, vUv).r;
+    vec3 col = turbo(v);
+    gl_FragColor = vec4(col, 0.55);
+  }
+`

--- a/packages/web-ui/src/core/EnclosureRenderer.tsx
+++ b/packages/web-ui/src/core/EnclosureRenderer.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { EffectComposer, SSAO, Bloom } from '@react-three/postprocessing'
+import { GPU } from 'gpu.js'
+import { EnclosureMesh } from '@components/EnclosureMesh'
+import { PressureField } from '@components/PressureField'
+import { PortFlowLines } from '@components/PortFlowLines'
+import { detectQuality, qualityPresets, type QualityKey, type QualityPreset } from '@lib/quality'
+import type { MeshData, AcousticNode } from '@types/index'
+
+type Props = {
+  geometry: MeshData
+  acousticNodes: AcousticNode[]
+  currentFreq: number
+}
+
+export function EnclosureRenderer({ geometry, acousticNodes, currentFreq }: Props) {
+  const gpuRef = useRef<GPU | null>(null)
+  const kernelRef = useRef<ReturnType<GPU['createKernel']> | null>(null)
+  const [qualityKey, setQualityKey] = useState<QualityKey>('desktop')
+  const [res, setRes] = useState(128)
+  const [zSlice] = useState(0.5)
+  const [field, setField] = useState<Float32Array>(() => new Float32Array(128 * 128))
+
+  useEffect(() => {
+    ;(async () => {
+      const quality = await detectQuality()
+      setQualityKey(quality)
+      setRes(qualityPresets[quality].pressureFieldRes)
+    })()
+  }, [])
+
+  useEffect(() => {
+    const gpu = gpuRef.current ?? new GPU()
+    gpuRef.current = gpu
+    kernelRef.current?.destroy?.()
+    const kernel = gpu
+      .createKernel(function (nodes: Float32Array, freq: number, t: number, nSources: number, zSliceVal: number, resolution: number) {
+        const x = this.thread.x / (resolution - 1)
+        const y = this.thread.y / (resolution - 1)
+        let pressure = 0.0
+        for (let i = 0; i < nSources; i += 1) {
+          const base = i * 4
+          const sx = nodes[base]
+          const sy = nodes[base + 1]
+          const sz = nodes[base + 2]
+          const amp = nodes[base + 3]
+          const dx = x - sx
+          const dy = y - sy
+          const dz = zSliceVal - sz
+          const r = Math.sqrt(dx * dx + dy * dy + dz * dz) + 1e-6
+          const phase = 6.28318530718 * freq * t - r / 340.0
+          pressure += amp * Math.sin(phase)
+        }
+        return pressure
+      })
+      .setOutput([res, res])
+      .setPipeline(false)
+      .setPrecision('single')
+    kernelRef.current = kernel
+    return () => {
+      kernel.destroy?.()
+    }
+  }, [res])
+
+  useEffect(() => {
+    setField(new Float32Array(res * res))
+  }, [res])
+
+  const nodesBuffer = useMemo(() => {
+    const buf = new Float32Array(Math.max(1, acousticNodes.length) * 4)
+    for (let i = 0; i < acousticNodes.length; i += 1) {
+      const node = acousticNodes[i]
+      buf[i * 4 + 0] = node.x
+      buf[i * 4 + 1] = node.y
+      buf[i * 4 + 2] = node.z
+      buf[i * 4 + 3] = node.amp
+    }
+    return buf
+  }, [acousticNodes])
+
+  useFrame((state) => {
+    const kernel = kernelRef.current
+    if (!kernel) return
+    const output = kernel(nodesBuffer, currentFreq, state.clock.elapsedTime, acousticNodes.length, zSlice, res) as number[][]
+    const nextField = new Float32Array(res * res)
+    let idx = 0
+    for (let y = 0; y < res; y += 1) {
+      const row = output[y]
+      for (let x = 0; x < res; x += 1) {
+        nextField[idx++] = row[x]
+      }
+    }
+    setField(nextField)
+  })
+
+  const preset: QualityPreset = useMemo(() => qualityPresets[qualityKey], [qualityKey])
+
+  return (
+    <>
+      <EffectComposer>
+        {preset.postProcessing && <SSAO radius={0.2} intensity={20} />}
+        <Bloom luminanceThreshold={0.85} intensity={0.2} />
+      </EffectComposer>
+      <EnclosureMesh geometry={geometry} />
+      <PressureField data={field} res={res} />
+      <PortFlowLines points={[[0, 0, 0], [1, 0, 0.1], [1, 1, 0.2]]} />
+    </>
+  )
+}

--- a/packages/web-ui/src/lib/protocol.ts
+++ b/packages/web-ui/src/lib/protocol.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod'
+
+const numericArray = z.union([
+  z.array(z.number()),
+  z.instanceof(Float32Array).transform((arr) => Array.from(arr)),
+  z.instanceof(Float64Array).transform((arr) => Array.from(arr)),
+  z.instanceof(Int16Array).transform((arr) => Array.from(arr as Int16Array).map(Number)),
+  z.instanceof(Int32Array).transform((arr) => Array.from(arr as Int32Array).map(Number)),
+  z.instanceof(Uint8Array).transform((arr) => Array.from(arr as Uint8Array).map(Number)),
+  z.instanceof(Uint16Array).transform((arr) => Array.from(arr as Uint16Array).map(Number)),
+  z.instanceof(Uint32Array).transform((arr) => Array.from(arr as Uint32Array).map(Number))
+])
+
+const iterationSchema = z.object({
+  type: z.literal('ITERATION'),
+  data: z.object({
+    iter: z.number().int().nonnegative().optional(),
+    loss: z.number().optional(),
+    gradNorm: z.number().optional(),
+    topology: z.string().optional(),
+    timestamp: z.number().optional(),
+    metrics: z.record(z.number()).optional(),
+    constraints: z.record(z.number()).optional(),
+    designVars: numericArray.optional(),
+    frequency: numericArray.optional(),
+    spl: numericArray.optional()
+  })
+})
+
+const topologySchema = z.object({
+  type: z.literal('TOPOLOGY_SWITCH'),
+  from: z.string().optional(),
+  to: z.string()
+})
+
+const violationSchema = z.object({
+  type: z.literal('CONSTRAINT_VIOLATION'),
+  constraint: z.string(),
+  location: z.any().optional(),
+  severity: z.number().optional()
+})
+
+const convergenceSchema = z.object({
+  type: z.literal('CONVERGENCE'),
+  data: z.object({
+    converged: z.boolean().optional(),
+    iterations: z.number().int().nonnegative().optional(),
+    finalLoss: z.number().optional(),
+    cpuTime: z.number().optional(),
+    solution: z.record(z.any()).optional()
+  })
+})
+
+const heartbeatSchema = z.object({
+  type: z.literal('HEARTBEAT'),
+  at: z.number()
+})
+
+export const solverMessageSchema = z.discriminatedUnion('type', [
+  iterationSchema,
+  topologySchema,
+  violationSchema,
+  convergenceSchema,
+  heartbeatSchema
+])
+
+export type SolverMessage = z.infer<typeof solverMessageSchema>
+export type IterationMessage = z.infer<typeof iterationSchema>["data"]
+export type ConstraintViolationMessage = z.infer<typeof violationSchema>
+export type TopologySwitchMessage = z.infer<typeof topologySchema>
+export type ConvergenceMessage = z.infer<typeof convergenceSchema>["data"]
+
+export function parseSolverMessage(payload: unknown): SolverMessage | null {
+  const result = solverMessageSchema.safeParse(payload)
+  if (!result.success) {
+    if (import.meta.env?.DEV) {
+      console.warn('Unrecognized solver payload', result.error.flatten())
+    }
+    return null
+  }
+  return result.data
+}

--- a/packages/web-ui/src/lib/quality.ts
+++ b/packages/web-ui/src/lib/quality.ts
@@ -1,0 +1,44 @@
+import { getGPUTier } from 'detect-gpu'
+
+export type QualityKey = 'mobile' | 'desktop' | 'workstation'
+
+export type QualityPreset = {
+  meshResolution: number
+  pressureFieldRes: number
+  shadows: boolean | 'soft'
+  postProcessing: boolean | 'full'
+  maxParticles: number
+  volumetricRendering?: boolean
+}
+
+export const qualityPresets: Record<QualityKey, QualityPreset> = {
+  mobile: {
+    meshResolution: 64,
+    pressureFieldRes: 64,
+    shadows: false,
+    postProcessing: false,
+    maxParticles: 2000
+  },
+  desktop: {
+    meshResolution: 256,
+    pressureFieldRes: 128,
+    shadows: 'soft',
+    postProcessing: true,
+    maxParticles: 20000
+  },
+  workstation: {
+    meshResolution: 512,
+    pressureFieldRes: 256,
+    shadows: 'soft',
+    postProcessing: 'full',
+    maxParticles: 120000,
+    volumetricRendering: false
+  }
+}
+
+export async function detectQuality(): Promise<QualityKey> {
+  const tier = await getGPUTier()
+  if (tier.tier >= 3) return 'workstation'
+  if (tier.tier >= 2) return 'desktop'
+  return 'mobile'
+}

--- a/packages/web-ui/src/lib/websocket.ts
+++ b/packages/web-ui/src/lib/websocket.ts
@@ -1,0 +1,119 @@
+import { unpack } from 'msgpackr'
+import { parseSolverMessage, type IterationMessage, type TopologySwitchMessage, type ConstraintViolationMessage, type ConvergenceMessage, type SolverMessage } from '@lib/protocol'
+
+export type ConnectionStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed'
+
+export type WSHandlers = {
+  onIteration?: (data: IterationMessage) => void
+  onTopology?: (data: TopologySwitchMessage) => void
+  onViolation?: (data: ConstraintViolationMessage) => void
+  onConvergence?: (data: ConvergenceMessage) => void
+  onRawMessage?: (message: SolverMessage) => void
+  onStatusChange?: (status: ConnectionStatus) => void
+  onError?: (ev: Event) => void
+}
+
+export class SolverWS {
+  private readonly url: string
+  private ws: WebSocket | null = null
+  private readonly handlers: WSHandlers
+  private backoff = 1000
+  private shouldReconnect = true
+  private status: ConnectionStatus = 'idle'
+
+  constructor(url: string, handlers: WSHandlers = {}) {
+    this.url = url
+    this.handlers = handlers
+  }
+
+  get connectionStatus(): ConnectionStatus {
+    return this.status
+  }
+
+  connect() {
+    if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+      return
+    }
+
+    this.shouldReconnect = true
+    this.updateStatus(this.ws ? 'reconnecting' : 'connecting')
+
+    this.ws = new WebSocket(this.url)
+    this.ws.binaryType = 'arraybuffer'
+
+    this.ws.onopen = () => {
+      this.backoff = 1000
+      this.updateStatus('open')
+    }
+
+    this.ws.onclose = () => {
+      this.ws = null
+      if (this.shouldReconnect) {
+        this.updateStatus('reconnecting')
+        setTimeout(() => this.reconnect(), this.backoff)
+        this.backoff = Math.min(10000, this.backoff * 1.7)
+      } else {
+        this.updateStatus('closed')
+      }
+    }
+
+    this.ws.onerror = (ev) => {
+      this.handlers.onError?.(ev)
+    }
+
+    this.ws.onmessage = async (ev) => {
+      const buf = ev.data instanceof ArrayBuffer ? ev.data : await (ev.data as Blob).arrayBuffer()
+      const unpacked = unpack(new Uint8Array(buf))
+      const message = parseSolverMessage(unpacked)
+      if (!message) {
+        return
+      }
+      this.handlers.onRawMessage?.(message)
+      switch (message.type) {
+        case 'ITERATION':
+          this.handlers.onIteration?.(message.data)
+          break
+        case 'TOPOLOGY_SWITCH':
+          this.handlers.onTopology?.(message)
+          break
+        case 'CONSTRAINT_VIOLATION':
+          this.handlers.onViolation?.(message)
+          break
+        case 'CONVERGENCE':
+          this.handlers.onConvergence?.(message.data)
+          break
+        default:
+          break
+      }
+    }
+  }
+
+  send(payload: unknown) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return
+    }
+    this.ws.send(payload as any)
+  }
+
+  private reconnect() {
+    if (!this.shouldReconnect) {
+      return
+    }
+    this.connect()
+  }
+
+  close() {
+    this.shouldReconnect = false
+    if (this.ws) {
+      this.ws.close()
+    } else {
+      this.updateStatus('closed')
+    }
+  }
+
+  private updateStatus(status: ConnectionStatus) {
+    if (this.status === status) return
+    this.status = status
+    this.handlers.onStatusChange?.(status)
+  }
+}

--- a/packages/web-ui/src/main.tsx
+++ b/packages/web-ui/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import App from './App'
+import './styles.css'
+
+const queryClient = new QueryClient()
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+)

--- a/packages/web-ui/src/stores/optimization.store.ts
+++ b/packages/web-ui/src/stores/optimization.store.ts
@@ -1,0 +1,344 @@
+import { create } from 'zustand'
+import type {
+  IterationMetrics,
+  OptParams,
+  OptimizationRun,
+  OptimizationRunResult
+} from '@types/index'
+import { SolverWS, type ConnectionStatus } from '@lib/websocket'
+import type {
+  ConvergenceMessage,
+  ConstraintViolationMessage,
+  IterationMessage,
+  TopologySwitchMessage
+} from '@lib/protocol'
+
+const iterationListeners = new Set<(data: IterationMetrics) => void>()
+
+const HISTORY_WINDOW = 256
+const API_BASE = import.meta.env.VITE_API_BASE ?? '/api'
+const POLL_INTERVAL_MS = 2000
+
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+function clearRunPoll() {
+  if (pollTimer != null) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+function clampHistory(values: number[], next?: number) {
+  if (next === undefined) return values
+  const updated = values.length >= HISTORY_WINDOW ? values.slice(values.length - HISTORY_WINDOW + 1) : [...values]
+  updated.push(next)
+  return updated
+}
+
+function normaliseNumberRecord(value: unknown): Record<string, number> | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const record: Record<string, number> = {}
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    const num = Number(raw)
+    if (!Number.isNaN(num)) {
+      record[key] = num
+    }
+  }
+  return Object.keys(record).length ? record : undefined
+}
+
+function normaliseSummaryRecord(value: unknown): Record<string, number | null> | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const record: Record<string, number | null> = {}
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (raw === null) {
+      record[key] = null
+    } else {
+      const num = Number(raw)
+      if (!Number.isNaN(num)) {
+        record[key] = num
+      }
+    }
+  }
+  return Object.keys(record).length ? record : undefined
+}
+
+function normaliseResponseRecord(value: unknown): Record<string, number[]> | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const record: Record<string, number[]> = {}
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (!Array.isArray(raw)) continue
+    const arr = raw.map((entry) => Number(entry)).filter((num) => !Number.isNaN(num))
+    if (arr.length) {
+      record[key] = arr
+    }
+  }
+  return Object.keys(record).length ? record : undefined
+}
+
+function normaliseHistory(entries: unknown): IterationMetrics[] | undefined {
+  if (!Array.isArray(entries)) return undefined
+  const mapped = entries
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return undefined
+      const iter = Number((entry as Record<string, unknown>).iter ?? 0)
+      if (Number.isNaN(iter)) return undefined
+      const loss = (entry as Record<string, unknown>).loss
+      const grad = (entry as Record<string, unknown>).gradNorm
+      const metrics = normaliseNumberRecord((entry as Record<string, unknown>).metrics)
+      return {
+        iter,
+        loss: loss != null ? Number(loss) : undefined,
+        gradNorm: grad != null ? Number(grad) : undefined,
+        metrics
+      } satisfies IterationMetrics
+    })
+    .filter((item): item is IterationMetrics => item !== undefined)
+  return mapped.length ? mapped : undefined
+}
+
+function normaliseRunResult(raw: unknown): OptimizationRunResult | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const obj = raw as Record<string, unknown>
+  const history = normaliseHistory(obj.history)
+  const convergenceRaw = obj.convergence as Record<string, unknown> | undefined
+  const convergence = convergenceRaw
+    ? {
+        converged: convergenceRaw.converged as boolean | undefined,
+        iterations: convergenceRaw.iterations as number | undefined,
+        finalLoss: convergenceRaw.finalLoss as number | undefined,
+        cpuTime: convergenceRaw.cpuTime as number | undefined,
+        solution: convergenceRaw.solution as Record<string, unknown> | undefined
+      }
+    : undefined
+  return {
+    history,
+    convergence,
+    summary: normaliseSummaryRecord(obj.summary),
+    response: normaliseResponseRecord(obj.response),
+    metrics: normaliseNumberRecord(obj.metrics)
+  }
+}
+
+function normaliseRun(raw: unknown): OptimizationRun | null {
+  if (!raw || typeof raw !== 'object') return null
+  const obj = raw as Record<string, unknown>
+  const id = obj.id
+  if (!id) return null
+  return {
+    id: String(id),
+    status: (obj.status as string | undefined) ?? 'queued',
+    created_at: Number(obj.created_at ?? Date.now() / 1000),
+    updated_at: Number(obj.updated_at ?? Date.now() / 1000),
+    params: (obj.params && typeof obj.params === 'object' ? (obj.params as Record<string, unknown>) : {}),
+    result: normaliseRunResult(obj.result),
+    error: typeof obj.error === 'string' ? obj.error : null
+  }
+}
+
+type OptimizationStore = {
+  status: ConnectionStatus
+  currentIteration: number
+  lastLoss: number | null
+  gradientNorm: number | null
+  topology: string | null
+  lossHistory: number[]
+  gradientHistory: number[]
+  lastMessageAt: number | null
+  lastIteration: IterationMetrics | null
+  convergence: ConvergenceMessage | null
+  violations: ConstraintViolationMessage[]
+  solverWS: SolverWS | null
+  activeRunId: string | null
+  lastRun: OptimizationRun | null
+  startOptimization: (params: OptParams) => Promise<void>
+  pauseOptimization: () => void
+  onIterationUpdate: (cb: (d: IterationMetrics) => void) => () => void
+}
+
+function toIterationMetrics(data: IterationMessage, fallbackIter: number): IterationMetrics {
+  return {
+    iter: data.iter ?? fallbackIter,
+    loss: data.loss,
+    gradNorm: data.gradNorm,
+    topology: data.topology,
+    timestamp: data.timestamp ?? Date.now(),
+    metrics: data.metrics
+  }
+}
+
+function handleTopologySwitch(data: TopologySwitchMessage | undefined, current: string | null) {
+  if (!data) return current
+  return data.to ?? current
+}
+
+export const useOptimization = create<OptimizationStore>((set, get) => {
+  const scheduleRunPolling = (runId: string) => {
+    clearRunPoll()
+    pollTimer = window.setInterval(async () => {
+      try {
+        const response = await fetch(`${API_BASE}/opt/${runId}`)
+        if (!response.ok) {
+          return
+        }
+        const payload = normaliseRun(await response.json())
+        if (!payload) return
+        set((state) => {
+          let lossHistory = state.lossHistory
+          let gradientHistory = state.gradientHistory
+          let currentIteration = state.currentIteration
+          let lastIteration = state.lastIteration
+          let lastLoss = state.lastLoss
+          let gradientNorm = state.gradientNorm
+
+          const runHistory = payload.result?.history
+          if (runHistory?.length) {
+            const newEntries = runHistory.filter((entry) => entry.iter > state.currentIteration)
+            if (newEntries.length) {
+              for (const entry of newEntries) {
+                lossHistory = clampHistory(lossHistory, entry.loss)
+                gradientHistory = clampHistory(gradientHistory, entry.gradNorm)
+              }
+              const latest = newEntries[newEntries.length - 1]
+              currentIteration = latest.iter
+              lastIteration = {
+                ...latest,
+                timestamp: Date.now(),
+                topology: latest.topology ?? state.topology
+              }
+              if (latest.loss != null) {
+                lastLoss = latest.loss
+              }
+              if (latest.gradNorm != null) {
+                gradientNorm = latest.gradNorm
+              }
+            }
+          }
+
+          const convergence = payload.result?.convergence
+            ? { ...state.convergence, ...payload.result.convergence }
+            : state.convergence
+
+          return {
+            lossHistory,
+            gradientHistory,
+            currentIteration,
+            lastIteration,
+            lastLoss,
+            gradientNorm,
+            lastMessageAt: Math.round(payload.updated_at * 1000),
+            convergence,
+            lastRun: payload
+          }
+        })
+
+        if (payload.status === 'succeeded' || payload.status === 'failed') {
+          clearRunPoll()
+        }
+      } catch (error) {
+        console.warn('Failed to poll optimisation run', error)
+      }
+    }, POLL_INTERVAL_MS)
+  }
+
+  const resetState = () =>
+    set({
+      currentIteration: 0,
+      lastLoss: null,
+      gradientNorm: null,
+      lossHistory: [],
+      gradientHistory: [],
+      lastIteration: null,
+      topology: null,
+      lastMessageAt: null,
+      convergence: null,
+      violations: [],
+      activeRunId: null,
+      lastRun: null
+    })
+
+  return {
+    status: 'idle',
+    currentIteration: 0,
+    lastLoss: null,
+    gradientNorm: null,
+    topology: null,
+    lossHistory: [],
+    gradientHistory: [],
+    lastMessageAt: null,
+    lastIteration: null,
+    convergence: null,
+    violations: [],
+    solverWS: null,
+    activeRunId: null,
+    lastRun: null,
+    onIterationUpdate: (cb) => {
+      iterationListeners.add(cb)
+      return () => iterationListeners.delete(cb)
+    },
+    startOptimization: async (params: OptParams) => {
+      const existing = get().solverWS
+      existing?.close()
+      clearRunPoll()
+      resetState()
+
+      const url = import.meta.env.VITE_SOLVER_WS_URL || 'ws://localhost:8787/ws'
+      const ws = new SolverWS(url, {
+        onIteration: (data) => {
+          const iterMetrics = toIterationMetrics(data, get().currentIteration + 1)
+          iterationListeners.forEach((listener) => listener(iterMetrics))
+          set((state) => ({
+            currentIteration: iterMetrics.iter,
+            lastLoss: iterMetrics.loss ?? state.lastLoss,
+            gradientNorm: iterMetrics.gradNorm ?? state.gradientNorm,
+            topology: iterMetrics.topology ?? state.topology,
+            lossHistory: clampHistory(state.lossHistory, iterMetrics.loss),
+            gradientHistory: clampHistory(state.gradientHistory, iterMetrics.gradNorm),
+            lastMessageAt: iterMetrics.timestamp,
+            lastIteration: iterMetrics
+          }))
+        },
+        onTopology: (data) => {
+          set((state) => ({ topology: handleTopologySwitch(data, state.topology) }))
+        },
+        onConvergence: (data) => {
+          set({ convergence: data })
+        },
+        onViolation: (data) => {
+          set((state) => ({ violations: [...state.violations, data] }))
+        },
+        onStatusChange: (status) => set({ status })
+      })
+
+      ws.connect()
+
+      set({ solverWS: ws, status: ws.connectionStatus })
+
+      try {
+        const response = await fetch(`${API_BASE}/opt/start`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(params)
+        })
+        if (response.ok) {
+          const payload = await response.json().catch(() => null)
+          const run = normaliseRun(payload)
+          if (run) {
+            set({ activeRunId: run.id, lastRun: run })
+            scheduleRunPolling(run.id)
+          }
+        } else {
+          console.warn('Failed to notify optimizer start', response.status)
+        }
+      } catch (error) {
+        console.warn('Failed to notify optimizer start', error)
+      }
+    },
+    pauseOptimization: () => {
+      clearRunPoll()
+      const wsInstance = get().solverWS
+      wsInstance?.close()
+      set({ solverWS: null, status: 'closed', activeRunId: null })
+    }
+  }
+})

--- a/packages/web-ui/src/styles.css
+++ b/packages/web-ui/src/styles.css
@@ -1,0 +1,170 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #020617;
+}
+
+html, body, #root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: radial-gradient(circle at top, rgba(30, 64, 175, 0.35), transparent 45%), #020617;
+  color: #f8fafc;
+}
+
+canvas {
+  outline: none;
+}
+
+.app-shell {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.app-loading {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  font-size: 1.25rem;
+  letter-spacing: 0.08em;
+}
+
+.hud {
+  position: absolute;
+  top: 1.5rem;
+  left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  width: min(22rem, calc(100% - 3rem));
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.9rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(14px);
+}
+
+.hud header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.hud__status {
+  color: #38bdf8;
+}
+
+.hud__badge {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  background: rgba(59, 130, 246, 0.25);
+  color: #bfdbfe;
+}
+
+.hud__badge--good {
+  background: rgba(34, 197, 94, 0.2);
+  color: #bbf7d0;
+}
+
+.hud__badge--progress {
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.75; }
+  50% { opacity: 1; }
+}
+
+.hud__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(6.5rem, 1fr));
+  gap: 0.75rem;
+}
+
+.hud__label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  color: #64748b;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.2rem;
+}
+
+.hud__value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.hud__muted {
+  margin-top: 0.2rem;
+  font-size: 0.7rem;
+  color: #94a3b8;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hud__spark {
+  display: flex;
+  justify-content: flex-end;
+  opacity: 0.85;
+}
+
+.hud__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.hud__button {
+  flex: 1;
+  appearance: none;
+  border: none;
+  border-radius: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  background: linear-gradient(135deg, #2563eb, #22d3ee);
+  color: #0f172a;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.hud__button:hover:enabled {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(56, 189, 248, 0.25);
+}
+
+.hud__button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.4);
+  opacity: 0.7;
+}
+
+.hud__button--secondary {
+  background: rgba(15, 23, 42, 0.6);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+@media (max-width: 768px) {
+  .hud {
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(24rem, calc(100% - 2rem));
+  }
+
+  .hud__row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/packages/web-ui/src/types/index.ts
+++ b/packages/web-ui/src/types/index.ts
@@ -1,0 +1,48 @@
+export type MeshData = {
+  vertices: Float32Array
+  indices: Uint32Array
+}
+
+export type AcousticNode = {
+  x: number
+  y: number
+  z: number
+  amp: number
+}
+
+export type IterationMetrics = {
+  iter: number
+  loss?: number
+  gradNorm?: number
+  topology?: string
+  timestamp?: number
+  metrics?: Record<string, number>
+}
+
+export type OptParams = Record<string, number>
+
+export type RunStatus = 'queued' | 'running' | 'succeeded' | 'failed'
+
+export type OptimizationRunResult = {
+  history?: IterationMetrics[]
+  convergence?: {
+    converged?: boolean
+    iterations?: number
+    finalLoss?: number
+    cpuTime?: number
+    solution?: Record<string, unknown>
+  }
+  summary?: Record<string, number | null>
+  response?: Record<string, number[]>
+  metrics?: Record<string, number>
+}
+
+export type OptimizationRun = {
+  id: string
+  status: RunStatus
+  created_at: number
+  updated_at: number
+  params: Record<string, unknown>
+  result?: OptimizationRunResult | null
+  error?: string | null
+}

--- a/packages/web-ui/tsconfig.json
+++ b/packages/web-ui/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "vite-env.d.ts"]
+}

--- a/packages/web-ui/vite-env.d.ts
+++ b/packages/web-ui/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/web-ui/vite.config.ts
+++ b/packages/web-ui/vite.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, loadEnv } from 'vite'
+import react from '@vitejs/plugin-react-swc'
+import path from 'node:path'
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@core': path.resolve(__dirname, 'src/core'),
+        '@components': path.resolve(__dirname, 'src/components'),
+        '@stores': path.resolve(__dirname, 'src/stores'),
+        '@lib': path.resolve(__dirname, 'src/lib'),
+        '@types': path.resolve(__dirname, 'src/types')
+      }
+    },
+    server: {
+      port: 5173,
+      host: true,
+      proxy: {
+        '/api': {
+          target: env.VITE_API_PROXY ?? 'http://localhost:8787',
+          changeOrigin: true
+        }
+      }
+    },
+    build: {
+      sourcemap: true,
+      target: 'es2020'
+    }
+  }
+})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bagger-spl"
+version = "0.1.0"
+description = "Core simulation and gateway scaffolding for the Bagger-SPL platform"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "mypy>=1.10.0",
+    "ruff>=0.5.6",
+]
+
+[tool.setuptools]
+package-dir = {"" = "python"}
+
+[tool.setuptools.packages.find]
+where = ["python"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+respect-gitignore = true
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "I", "UP"]
+ignore = ["E203", "E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["spl_core"]
+
+[tool.mypy]
+python_version = "3.11"
+files = ["python", "services"]
+mypy_path = ["python"]
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_optional = true
+namespace_packages = true
+implicit_reexport = false
+
+[[tool.mypy.overrides]]
+module = ["fastapi", "pydantic"]
+ignore_missing_imports = true

--- a/python/spl_core/__init__.py
+++ b/python/spl_core/__init__.py
@@ -1,0 +1,44 @@
+"""Public interface for the Bagger-SPL simulation core."""
+
+from .acoustics.sealed import (
+    SealedAlignmentSummary,
+    SealedBoxResponse,
+    SealedBoxSolver,
+)
+from .acoustics.vented import (
+    VentedAlignmentSummary,
+    VentedBoxResponse,
+    VentedBoxSolver,
+)
+from .drivers import BoxDesign, DriverParameters, PortGeometry, VentedBoxDesign
+from .serialization import (
+    dataclass_schema,
+    sealed_simulation_request_schema,
+    sealed_simulation_response_schema,
+    sealed_simulation_schema,
+    solver_json_schemas,
+    vented_simulation_request_schema,
+    vented_simulation_response_schema,
+    vented_simulation_schema,
+)
+
+__all__ = [
+    "DriverParameters",
+    "BoxDesign",
+    "PortGeometry",
+    "VentedBoxDesign",
+    "SealedBoxSolver",
+    "SealedBoxResponse",
+    "SealedAlignmentSummary",
+    "VentedBoxSolver",
+    "VentedBoxResponse",
+    "VentedAlignmentSummary",
+    "dataclass_schema",
+    "sealed_simulation_request_schema",
+    "sealed_simulation_response_schema",
+    "sealed_simulation_schema",
+    "vented_simulation_request_schema",
+    "vented_simulation_response_schema",
+    "vented_simulation_schema",
+    "solver_json_schemas",
+]

--- a/python/spl_core/acoustics/__init__.py
+++ b/python/spl_core/acoustics/__init__.py
@@ -1,0 +1,13 @@
+"""Acoustic solver implementations."""
+
+from .sealed import SealedAlignmentSummary, SealedBoxResponse, SealedBoxSolver
+from .vented import VentedAlignmentSummary, VentedBoxResponse, VentedBoxSolver
+
+__all__ = [
+    "SealedBoxSolver",
+    "SealedBoxResponse",
+    "SealedAlignmentSummary",
+    "VentedBoxSolver",
+    "VentedBoxResponse",
+    "VentedAlignmentSummary",
+]

--- a/python/spl_core/acoustics/_utils.py
+++ b/python/spl_core/acoustics/_utils.py
@@ -1,0 +1,74 @@
+"""Utility helpers shared across acoustic solvers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def find_band_edges(
+    frequencies: Sequence[float],
+    values: Sequence[float],
+    drop_db: float,
+) -> tuple[float | None, float | None]:
+    """Return approximate low/high frequencies where ``values`` fall ``drop_db`` below the peak.
+
+    The inputs are treated as sampled points of a smooth response curve. The search assumes
+    ``frequencies`` are unique but not necessarily sorted. Linear interpolation is used to
+    estimate the crossing locations around the global peak. When no crossing is detected on
+    a given side of the peak (e.g. monotonically increasing samples) the nearest boundary
+    frequency is returned instead of ``None`` to signal the limited bandwidth capture.
+    """
+
+    if len(frequencies) != len(values) or not frequencies:
+        return (None, None)
+
+    pairs = sorted(zip(frequencies, values, strict=False), key=lambda item: item[0])
+    freqs: list[float] = [float(freq) for freq, _ in pairs]
+    mags: list[float] = [float(mag) for _, mag in pairs]
+
+    peak_val = max(mags)
+    threshold = peak_val - drop_db
+    peak_idx = mags.index(peak_val)
+
+    low = _search_edge(freqs, mags, peak_idx, -1, threshold)
+    high = _search_edge(freqs, mags, peak_idx, 1, threshold)
+    return (low, high)
+
+
+def _search_edge(
+    freqs: Sequence[float],
+    mags: Sequence[float],
+    start_idx: int,
+    step: int,
+    threshold: float,
+) -> float | None:
+    prev_freq = freqs[start_idx]
+    prev_val = mags[start_idx]
+
+    idx = start_idx + step
+    while 0 <= idx < len(freqs):
+        freq = freqs[idx]
+        val = mags[idx]
+        if val == threshold:
+            return freq
+        if _crosses(prev_val, val, threshold):
+            return _interpolate(prev_freq, prev_val, freq, val, threshold)
+        prev_freq = freq
+        prev_val = val
+        idx += step
+
+    return prev_freq
+
+
+def _crosses(a: float, b: float, threshold: float) -> bool:
+    return (a - threshold) * (b - threshold) <= 0.0 and a != b
+
+
+def _interpolate(f1: float, v1: float, f2: float, v2: float, threshold: float) -> float:
+    if v2 == v1:
+        return (f1 + f2) / 2.0
+    ratio = (threshold - v1) / (v2 - v1)
+    return f1 + ratio * (f2 - f1)
+
+
+__all__ = ["find_band_edges"]

--- a/python/spl_core/acoustics/sealed.py
+++ b/python/spl_core/acoustics/sealed.py
@@ -1,0 +1,176 @@
+"""Simplified sealed-box acoustic solver.
+
+This module intentionally focuses on analytical formulations that run without
+third-party numerical dependencies. The implementation provides a physics-
+grounded baseline that we can extend with higher fidelity models (modal
+extensions, non-linear suspension) in later milestones.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from math import log10, pi, sqrt
+
+from ..drivers import AIR_DENSITY, BoxDesign, DriverParameters
+from ._utils import find_band_edges
+
+P_REF = 20e-6  # 20 µPa reference pressure for SPL
+
+
+@dataclass(slots=True)
+class SealedBoxResponse:
+    """Frequency-domain response of a sealed-box system."""
+
+    frequency_hz: list[float]
+    spl_db: list[float]
+    impedance_ohm: list[complex]
+    cone_velocity_ms: list[float]
+    cone_displacement_m: list[float]
+
+    def to_dict(self) -> dict[str, list[float]]:
+        """Return a JSON-serialisable representation of the response."""
+
+        return {
+            "frequency_hz": list(self.frequency_hz),
+            "spl_db": list(self.spl_db),
+            "impedance_real": [float(z.real) for z in self.impedance_ohm],
+            "impedance_imag": [float(z.imag) for z in self.impedance_ohm],
+            "cone_velocity_ms": list(self.cone_velocity_ms),
+            "cone_displacement_m": list(self.cone_displacement_m),
+        }
+
+
+@dataclass(slots=True)
+class SealedAlignmentSummary:
+    """Key figures of merit describing a sealed alignment."""
+
+    fc_hz: float
+    qtc: float
+    f3_low_hz: float | None
+    f3_high_hz: float | None
+    max_spl_db: float
+    max_cone_velocity_ms: float
+    max_cone_displacement_m: float
+    excursion_ratio: float | None
+    excursion_headroom_db: float | None
+    safe_drive_voltage_v: float | None
+
+    def to_dict(self) -> dict[str, float | None]:
+        return {
+            "fc_hz": self.fc_hz,
+            "qtc": self.qtc,
+            "f3_low_hz": self.f3_low_hz,
+            "f3_high_hz": self.f3_high_hz,
+            "max_spl_db": self.max_spl_db,
+            "max_cone_velocity_ms": self.max_cone_velocity_ms,
+            "max_cone_displacement_m": self.max_cone_displacement_m,
+            "excursion_ratio": self.excursion_ratio,
+            "excursion_headroom_db": self.excursion_headroom_db,
+            "safe_drive_voltage_v": self.safe_drive_voltage_v,
+        }
+
+
+class SealedBoxSolver:
+    """Analytical solver for classic sealed enclosures."""
+
+    def __init__(self, driver: DriverParameters, box: BoxDesign, drive_voltage: float = 2.83):
+        self.driver = driver
+        self.box = box
+        self.drive_voltage = drive_voltage
+
+        self._cms = driver.compliance()
+        self._cab = box.air_compliance(driver)
+        self._cms_total = 1.0 / (1.0 / self._cms + 1.0 / self._cab)
+
+        self._w_s = 2 * pi * driver.fs_hz
+        self._qes = driver.qes()
+        self._qms = driver.qms()
+        self._rms = driver.mechanical_resistance()
+
+    def system_resonance(self) -> float:
+        """Return the resonance frequency (Fc) of the boxed system."""
+
+        return 1.0 / (2 * pi * sqrt(self.driver.mms_kg * self._cms_total))
+
+    def system_qtc(self) -> float:
+        """Return total system Q including electrical damping."""
+
+        qes_box = self._qes * (self._cms / self._cms_total)
+        inv_qtc = 1.0 / self._qms + 1.0 / qes_box
+        return 1.0 / inv_qtc
+
+    def frequency_response(self, frequencies_hz: Iterable[float], mic_distance_m: float = 1.0) -> SealedBoxResponse:
+        """Compute SPL/impedance over the requested frequencies."""
+
+        freq_list: list[float] = []
+        spl_list: list[float] = []
+        imp_list: list[complex] = []
+        vel_list: list[float] = []
+        disp_list: list[float] = []
+
+        cms_total = self._cms_total
+        driver = self.driver
+
+        for f in frequencies_hz:
+            if f <= 0:
+                continue
+            omega = 2 * pi * f
+
+            # Mechanical impedance of the moving system + box air load
+            zm = self._rms + 1j * (omega * driver.mms_kg - 1.0 / (omega * cms_total))
+
+            # Total electrical impedance seen by the amplifier
+            ze = driver.re_ohm + 1j * omega * driver.le_h + (driver.bl_t_m**2) / zm
+
+            current = self.drive_voltage / ze
+            force = driver.bl_t_m * current
+            velocity = force / zm
+            volume_velocity = velocity * driver.sd_m2
+
+            pressure = omega * AIR_DENSITY * abs(volume_velocity) / (2 * pi * mic_distance_m)
+            spl = 20.0 * log10(max(pressure / P_REF, 1e-12))
+
+            freq_list.append(f)
+            spl_list.append(spl)
+            imp_list.append(ze)
+            displacement = abs(velocity) / max(omega, 1e-9)
+
+            vel_list.append(abs(velocity))
+            disp_list.append(displacement)
+
+        return SealedBoxResponse(freq_list, spl_list, imp_list, vel_list, disp_list)
+
+    def alignment_summary(self, response: SealedBoxResponse) -> SealedAlignmentSummary:
+        """Derive key alignment metrics from a previously computed response."""
+
+        max_spl = max(response.spl_db, default=0.0)
+        f3_low, f3_high = find_band_edges(response.frequency_hz, response.spl_db, 3.0)
+        max_velocity = max(response.cone_velocity_ms, default=0.0)
+        max_displacement = max(response.cone_displacement_m, default=0.0)
+
+        excursion_ratio: float | None = None
+        excursion_headroom_db: float | None = None
+        safe_drive: float | None = None
+
+        xmax = self.driver.xmax_m()
+        if xmax and max_displacement > 0.0:
+            excursion_ratio = max_displacement / xmax
+            excursion_headroom_db = -20.0 * log10(excursion_ratio)
+            safe_drive = self.drive_voltage / max(excursion_ratio, 1.0)
+
+        return SealedAlignmentSummary(
+            fc_hz=self.system_resonance(),
+            qtc=self.system_qtc(),
+            f3_low_hz=f3_low,
+            f3_high_hz=f3_high,
+            max_spl_db=max_spl,
+            max_cone_velocity_ms=max_velocity,
+            max_cone_displacement_m=max_displacement,
+            excursion_ratio=excursion_ratio,
+            excursion_headroom_db=excursion_headroom_db,
+            safe_drive_voltage_v=safe_drive,
+        )
+
+
+__all__ = ["SealedBoxSolver", "SealedBoxResponse", "SealedAlignmentSummary"]

--- a/python/spl_core/acoustics/vented.py
+++ b/python/spl_core/acoustics/vented.py
@@ -1,0 +1,190 @@
+"""Analytical vented-box solver built on classic lumped parameters."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from math import log10, pi
+
+from ..drivers import AIR_DENSITY, DriverParameters, PortGeometry, VentedBoxDesign
+from ._utils import find_band_edges
+from .sealed import P_REF
+
+
+@dataclass(slots=True)
+class VentedBoxResponse:
+    """Frequency response summary for a vented alignment."""
+
+    frequency_hz: list[float]
+    spl_db: list[float]
+    impedance_ohm: list[complex]
+    cone_velocity_ms: list[float]
+    cone_displacement_m: list[float]
+    port_air_velocity_ms: list[float]
+
+    def to_dict(self) -> dict[str, list[float]]:
+        return {
+            "frequency_hz": list(self.frequency_hz),
+            "spl_db": list(self.spl_db),
+            "impedance_real": [float(z.real) for z in self.impedance_ohm],
+            "impedance_imag": [float(z.imag) for z in self.impedance_ohm],
+            "cone_velocity_ms": list(self.cone_velocity_ms),
+            "cone_displacement_m": list(self.cone_displacement_m),
+            "port_velocity_ms": list(self.port_air_velocity_ms),
+        }
+
+
+@dataclass(slots=True)
+class VentedAlignmentSummary:
+    """Key figures describing the vented system alignment."""
+
+    fb_hz: float
+    f3_low_hz: float | None
+    f3_high_hz: float | None
+    max_spl_db: float
+    max_cone_velocity_ms: float
+    max_cone_displacement_m: float
+    max_port_velocity_ms: float
+    excursion_ratio: float | None
+    excursion_headroom_db: float | None
+    safe_drive_voltage_v: float | None
+
+    def to_dict(self) -> dict[str, float | None]:
+        return {
+            "fb_hz": self.fb_hz,
+            "f3_low_hz": self.f3_low_hz,
+            "f3_high_hz": self.f3_high_hz,
+            "max_spl_db": self.max_spl_db,
+            "max_cone_velocity_ms": self.max_cone_velocity_ms,
+            "max_cone_displacement_m": self.max_cone_displacement_m,
+            "max_port_velocity_ms": self.max_port_velocity_ms,
+            "excursion_ratio": self.excursion_ratio,
+            "excursion_headroom_db": self.excursion_headroom_db,
+            "safe_drive_voltage_v": self.safe_drive_voltage_v,
+        }
+
+
+class VentedBoxSolver:
+    """Simplified bass-reflex solver using lumped acoustic elements."""
+
+    def __init__(
+        self,
+        driver: DriverParameters,
+        box: VentedBoxDesign,
+        drive_voltage: float = 2.83,
+    ) -> None:
+        if drive_voltage <= 0:
+            raise ValueError("Drive voltage must be positive")
+
+        self.driver = driver
+        self.box = box
+        self.drive_voltage = drive_voltage
+
+        self._cms = driver.compliance()
+        self._cab_acoustic = box.acoustic_compliance()
+        self._port: PortGeometry = box.port
+
+        self._map = self._port.acoustic_mass()
+        self._rap = self._port.series_resistance(self._cab_acoustic)
+        self._rleak = box.leakage_resistance(self._cab_acoustic)
+
+        self._rms = driver.mechanical_resistance()
+
+    def tuning_frequency(self) -> float:
+        """Return the enclosure tuning frequency (Fb)."""
+
+        return self._port.tuning_frequency(self._cab_acoustic)
+
+    def frequency_response(
+        self,
+        frequencies_hz: Iterable[float],
+        mic_distance_m: float = 1.0,
+    ) -> VentedBoxResponse:
+        """Compute SPL, impedance, and velocity traces for the vented system."""
+
+        if mic_distance_m <= 0:
+            raise ValueError("Microphone distance must be positive")
+
+        freq_list: list[float] = []
+        spl_list: list[float] = []
+        imp_list: list[complex] = []
+        cone_vel_list: list[float] = []
+        disp_list: list[float] = []
+        port_vel_list: list[float] = []
+
+        driver = self.driver
+        sd_sq = driver.sd_m2**2
+        port_area = max(self._port.area_m2(), 1e-9)
+
+        for f in frequencies_hz:
+            if f <= 0:
+                continue
+
+            omega = 2 * pi * f
+
+            z_cab = 1.0 / (1j * omega * self._cab_acoustic)
+            if self._rleak is not None:
+                z_cab = 1.0 / (1.0 / z_cab + 1.0 / self._rleak)
+
+            z_port = self._rap + 1j * omega * self._map
+            z_load = 1.0 / (1.0 / z_cab + 1.0 / z_port)
+
+            z_mech = self._rms + 1j * omega * driver.mms_kg + 1.0 / (1j * omega * self._cms)
+            z_total_mech = z_mech + sd_sq * z_load
+
+            ze = driver.re_ohm + 1j * omega * driver.le_h + (driver.bl_t_m**2) / z_total_mech
+
+            current = self.drive_voltage / ze
+            force = driver.bl_t_m * current
+            cone_velocity = force / z_total_mech
+            volume_velocity = cone_velocity * driver.sd_m2
+
+            pressure = omega * AIR_DENSITY * abs(volume_velocity) / (2 * pi * mic_distance_m)
+            spl = 20.0 * log10(max(pressure / P_REF, 1e-12))
+
+            acoustic_pressure = z_load * volume_velocity
+            port_volume_velocity = acoustic_pressure / z_port
+            port_velocity = abs(port_volume_velocity) / port_area
+            displacement = abs(cone_velocity) / max(omega, 1e-9)
+
+            freq_list.append(f)
+            spl_list.append(spl)
+            imp_list.append(ze)
+            cone_vel_list.append(abs(cone_velocity))
+            disp_list.append(displacement)
+            port_vel_list.append(port_velocity)
+
+        return VentedBoxResponse(freq_list, spl_list, imp_list, cone_vel_list, disp_list, port_vel_list)
+
+    def alignment_summary(self, response: VentedBoxResponse) -> VentedAlignmentSummary:
+        max_spl = max(response.spl_db, default=0.0)
+        f3_low, f3_high = find_band_edges(response.frequency_hz, response.spl_db, 3.0)
+        max_cone_velocity = max(response.cone_velocity_ms, default=0.0)
+        max_cone_displacement = max(response.cone_displacement_m, default=0.0)
+        max_port_velocity = max(response.port_air_velocity_ms, default=0.0)
+
+        excursion_ratio: float | None = None
+        excursion_headroom_db: float | None = None
+        safe_drive: float | None = None
+
+        xmax = self.driver.xmax_m()
+        if xmax and max_cone_displacement > 0.0:
+            excursion_ratio = max_cone_displacement / xmax
+            excursion_headroom_db = -20.0 * log10(excursion_ratio)
+            safe_drive = self.drive_voltage / max(excursion_ratio, 1.0)
+
+        return VentedAlignmentSummary(
+            fb_hz=self.tuning_frequency(),
+            f3_low_hz=f3_low,
+            f3_high_hz=f3_high,
+            max_spl_db=max_spl,
+            max_cone_velocity_ms=max_cone_velocity,
+            max_cone_displacement_m=max_cone_displacement,
+            max_port_velocity_ms=max_port_velocity,
+            excursion_ratio=excursion_ratio,
+            excursion_headroom_db=excursion_headroom_db,
+            safe_drive_voltage_v=safe_drive,
+        )
+
+
+__all__ = ["VentedBoxSolver", "VentedBoxResponse", "VentedAlignmentSummary"]

--- a/python/spl_core/drivers.py
+++ b/python/spl_core/drivers.py
@@ -1,0 +1,237 @@
+"""Driver and enclosure data models used across the simulation core."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from math import pi, sqrt
+
+AIR_DENSITY = 1.2041  # kg/m^3 at 20°C
+SPEED_OF_SOUND = 343.0  # m/s at 20°C
+
+
+@dataclass(slots=True)
+class DriverParameters:
+    """Minimal Thiele/Small parameter set for low-frequency simulations."""
+
+    fs_hz: float
+    """Free-air resonance frequency (Hz)."""
+
+    qts: float
+    """Total Q at fs (dimensionless)."""
+
+    re_ohm: float
+    """DC resistance of the voice coil (ohms)."""
+
+    bl_t_m: float
+    """Force factor (Tesla-metres)."""
+
+    mms_kg: float
+    """Moving mass including air load (kilograms)."""
+
+    sd_m2: float
+    """Effective piston area (square metres)."""
+
+    le_h: float = 0.0007
+    """Voice-coil inductance (Henries)."""
+
+    vas_l: float | None = None
+    """Equivalent compliance volume (litres). Optional if Cms derived from fs/mms."""
+
+    xmax_mm: float | None = None
+    """One-way linear excursion limit (millimetres)."""
+
+    def vas_m3(self) -> float:
+        """Return the compliance volume in cubic metres."""
+
+        if self.vas_l is not None:
+            return self.vas_l / 1000.0
+        return self.compliance() * AIR_DENSITY * SPEED_OF_SOUND**2 * self.sd_m2**2
+
+    def compliance(self) -> float:
+        """Return the mechanical compliance Cms (m/N)."""
+
+        return 1.0 / ((2 * pi * self.fs_hz) ** 2 * self.mms_kg)
+
+    def qes(self) -> float:
+        """Electrical Q derived from BL, Re, and moving mass."""
+
+        w_s = 2 * pi * self.fs_hz
+        return (w_s * self.mms_kg * self.re_ohm) / (self.bl_t_m**2)
+
+    def qms(self) -> float:
+        """Mechanical Q derived from Qts and Qes."""
+
+        qes = self.qes()
+        if qes <= 0:
+            raise ValueError("Qes must be positive")
+        inv_qms = 1.0 / self.qts - 1.0 / qes
+        if inv_qms <= 0:
+            # fall back to lightly damped assumption
+            inv_qms = 1.0 / (self.qts * 1.2)
+        return 1.0 / inv_qms
+
+    def mechanical_resistance(self) -> float:
+        """Return Rms (mechanical losses) in N·s/m."""
+
+        w_s = 2 * pi * self.fs_hz
+        return (w_s * self.mms_kg) / self.qms()
+
+    def xmax_m(self) -> float | None:
+        """Return the linear excursion limit in metres if provided."""
+
+        if self.xmax_mm is None:
+            return None
+        return self.xmax_mm / 1000.0
+
+    def compliance_curve(
+        self,
+        displacements_mm: Iterable[float],
+        *,
+        softening_factor: float = 0.45,
+        stiffening_factor: float = 0.12,
+    ) -> list[tuple[float, float]]:
+        """Return a symmetric Cms(x) approximation across the supplied offsets.
+
+        The curve follows a gentle softening profile up to the declared ``xmax`` and
+        gradually stiffens beyond the limit to reflect suspension end-stops. When
+        ``xmax`` is not provided the function infers a reference excursion from the
+        sampled range so callers can still obtain a well behaved curve for visual
+        feedback.
+        """
+
+        samples = [float(x) for x in displacements_mm]
+        if not samples:
+            return []
+
+        base_cms = self.compliance()
+        ref_limit_m = self.xmax_m()
+        if ref_limit_m is None:
+            peak_mm = max(abs(x) for x in samples)
+            ref_limit_m = max(peak_mm / 1000.0, 1e-6)
+
+        curve: list[tuple[float, float]] = []
+        for offset_mm in samples:
+            offset_m = offset_mm / 1000.0
+            ratio = min(abs(offset_m) / ref_limit_m, 4.0)
+
+            # Softening around the middle of the suspension travel followed by a
+            # progressive stiffening once the excursion approaches mechanical stops.
+            softening = 1.0 + softening_factor * ratio**2
+            stiffening = 1.0 + stiffening_factor * max(ratio - 1.0, 0.0) ** 2
+            cms = base_cms * softening / stiffening
+            curve.append((offset_mm, cms))
+
+        return curve
+
+
+@dataclass(slots=True)
+class BoxDesign:
+    """Parameters describing a sealed enclosure."""
+
+    volume_l: float
+    """Net internal volume (litres)."""
+
+    leakage_q: float = 15.0
+    """Optional leakage quality factor (larger => lower leakage)."""
+
+    def volume_m3(self) -> float:
+        """Return enclosure volume in cubic metres."""
+
+        return self.volume_l / 1000.0
+
+    def air_compliance(self, driver: DriverParameters) -> float:
+        """Return Cab, the acoustic compliance of the enclosed air."""
+
+        return self.volume_m3() / (AIR_DENSITY * SPEED_OF_SOUND**2 * driver.sd_m2**2)
+
+
+@dataclass(slots=True)
+class PortGeometry:
+    """Simple representation of a circular port."""
+
+    diameter_m: float
+    """Port diameter (metres)."""
+
+    length_m: float
+    """Physical tube length (metres)."""
+
+    count: int = 1
+    """Number of identical ports."""
+
+    flare_factor: float = 1.7
+    """End-correction multiplier (~1.7 for one flanged, one free end)."""
+
+    loss_q: float = 18.0
+    """Quality factor capturing port losses (higher => lower damping)."""
+
+    def area_m2(self) -> float:
+        """Return the combined cross-sectional area of all ports."""
+
+        radius = self.diameter_m / 2.0
+        single_area = pi * radius**2
+        return single_area * max(self.count, 1)
+
+    def effective_length_m(self) -> float:
+        """Return the acoustically effective length including end correction."""
+
+        radius = self.diameter_m / 2.0
+        return self.length_m + self.flare_factor * radius
+
+    def acoustic_mass(self) -> float:
+        """Return acoustic mass Map (Pa·s²/m³)."""
+
+        area = self.area_m2()
+        if area <= 0:
+            raise ValueError("Port area must be positive")
+        return AIR_DENSITY * self.effective_length_m() / area
+
+    def tuning_frequency(self, cab_acoustic: float) -> float:
+        """Return the box tuning frequency derived from Map and acoustic Cab."""
+
+        omega0 = 1.0 / sqrt(self.acoustic_mass() * cab_acoustic)
+        return omega0 / (2 * pi)
+
+    def series_resistance(self, cab_acoustic: float) -> float:
+        """Return an approximate acoustic resistance modelling port losses."""
+
+        loss_q = max(self.loss_q, 0.5)
+        omega0 = 2 * pi * self.tuning_frequency(cab_acoustic)
+        return omega0 * self.acoustic_mass() / loss_q
+
+
+@dataclass(slots=True)
+class VentedBoxDesign:
+    """Parameters describing a bass-reflex (vented) enclosure."""
+
+    volume_l: float
+    """Net internal volume (litres)."""
+
+    port: PortGeometry
+    """Primary port geometry."""
+
+    leakage_q: float = 10.0
+    """Quality factor representing box leakage/absorption losses."""
+
+    def volume_m3(self) -> float:
+        """Return enclosure volume in cubic metres."""
+
+        return self.volume_l / 1000.0
+
+    def air_compliance(self, driver: DriverParameters) -> float:
+        """Return mechanical compliance of the enclosed air referenced to the cone."""
+
+        return self.volume_m3() / (AIR_DENSITY * SPEED_OF_SOUND**2 * driver.sd_m2**2)
+
+    def acoustic_compliance(self) -> float:
+        """Return acoustic compliance (Cab) in the acoustic domain."""
+
+        return self.volume_m3() / (AIR_DENSITY * SPEED_OF_SOUND**2)
+
+    def leakage_resistance(self, cab_acoustic: float) -> float | None:
+        """Return an acoustic resistance approximating leakage losses."""
+
+        if self.leakage_q <= 0:
+            return None
+        omega0 = 2 * pi * self.port.tuning_frequency(cab_acoustic)
+        return self.leakage_q / (omega0 * cab_acoustic)

--- a/python/spl_core/serialization.py
+++ b/python/spl_core/serialization.py
@@ -1,0 +1,414 @@
+"""JSON schema helpers describing solver request/response contracts.
+
+These helpers provide lightweight JSON Schema v2020-12 documents for the
+analytical solvers so other services (FastAPI gateway, Studio UI, CLI) can
+consume the same request/response contracts without duplicating structure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import MISSING, fields, is_dataclass
+from types import UnionType
+from typing import Any, Union, get_args, get_origin, get_type_hints
+
+from .acoustics.sealed import SealedAlignmentSummary
+from .acoustics.vented import VentedAlignmentSummary
+from .drivers import BoxDesign, DriverParameters, PortGeometry, VentedBoxDesign
+
+SCHEMA_DRAFT = "https://json-schema.org/draft/2020-12/schema"
+
+
+def dataclass_schema(
+    cls: type[Any],
+    *,
+    field_overrides: Mapping[str, Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return a JSON schema describing the given dataclass."""
+
+    if not is_dataclass(cls):  # pragma: no cover - defensive guard
+        raise TypeError(f"{cls!r} is not a dataclass")
+
+    overrides: Mapping[str, Mapping[str, Any]] | None = field_overrides or _DATACLASS_OVERRIDES.get(cls)
+    type_hints = get_type_hints(cls)
+
+    properties: dict[str, dict[str, Any]] = {}
+    required: list[str] = []
+
+    for field in fields(cls):
+        field_type = type_hints.get(field.name, field.type)
+        schema = _schema_for_type(field_type)
+        properties[field.name] = schema
+        if field.default is MISSING and field.default_factory is MISSING:
+            required.append(field.name)
+
+    schema_doc: dict[str, Any] = {
+        "title": cls.__name__,
+        "type": "object",
+        "additionalProperties": False,
+        "properties": properties,
+        "required": required,
+    }
+
+    if overrides:
+        for name, override in overrides.items():
+            prop = properties.get(name)
+            if not prop:
+                continue
+            _apply_override(prop, override)
+
+    return schema_doc
+
+
+def sealed_simulation_request_schema() -> dict[str, Any]:
+    """Return the JSON schema describing the sealed solver request payload."""
+
+    return {
+        "$schema": SCHEMA_DRAFT,
+        "title": "SealedBoxSimulationRequest",
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["driver", "box", "frequencies_hz"],
+        "properties": {
+            "driver": dataclass_schema(DriverParameters),
+            "box": dataclass_schema(BoxDesign),
+            "frequencies_hz": _number_array_schema(
+                title="Frequency bins (Hz)",
+                min_items=1,
+                description="Discrete frequencies to evaluate.",
+            ),
+            "mic_distance_m": _positive_number_schema(
+                "Microphone distance (m)",
+                description="Distance from driver to virtual microphone.",
+            ),
+            "drive_voltage": _positive_number_schema(
+                "Drive voltage (Vrms)",
+                description="Input voltage driving the system (RMS).",
+            ),
+        },
+    }
+
+
+def sealed_simulation_response_schema() -> dict[str, Any]:
+    """Return the JSON schema for the sealed solver response payload."""
+
+    summary_schema = dataclass_schema(SealedAlignmentSummary)
+    schema = _base_response_schema(
+        title="SealedBoxSimulationResponse",
+        summary_schema=summary_schema,
+        extra_properties={
+            "fc_hz": {
+                "type": "number",
+                "description": "System resonance frequency (Fc).",
+            },
+            "qtc": {
+                "type": "number",
+                "description": "Total system Q including electrical damping.",
+            },
+        },
+        extra_required=("fc_hz", "qtc"),
+    )
+    return schema
+
+
+def vented_simulation_request_schema() -> dict[str, Any]:
+    """Return the JSON schema describing the vented solver request payload."""
+
+    return {
+        "$schema": SCHEMA_DRAFT,
+        "title": "VentedBoxSimulationRequest",
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["driver", "box", "frequencies_hz"],
+        "properties": {
+            "driver": dataclass_schema(DriverParameters),
+            "box": dataclass_schema(VentedBoxDesign),
+            "frequencies_hz": _number_array_schema(
+                title="Frequency bins (Hz)",
+                min_items=1,
+                description="Discrete frequencies to evaluate.",
+            ),
+            "mic_distance_m": _positive_number_schema(
+                "Microphone distance (m)",
+                description="Distance from driver to virtual microphone.",
+            ),
+            "drive_voltage": _positive_number_schema(
+                "Drive voltage (Vrms)",
+                description="Input voltage driving the system (RMS).",
+            ),
+        },
+    }
+
+
+def vented_simulation_response_schema() -> dict[str, Any]:
+    """Return the JSON schema for the vented solver response payload."""
+
+    summary_schema = dataclass_schema(VentedAlignmentSummary)
+    schema = _base_response_schema(
+        title="VentedBoxSimulationResponse",
+        summary_schema=summary_schema,
+        extra_properties={
+            "port_velocity_ms": _number_array_schema(
+                title="Port air velocity (m/s)",
+                min_items=1,
+                description="Velocity magnitude of air inside the port.",
+            ),
+            "fb_hz": {
+                "type": "number",
+                "description": "Box tuning frequency (Fb).",
+            },
+            "max_port_velocity_ms": {
+                "type": "number",
+                "description": "Maximum port air velocity observed across frequencies.",
+            },
+        },
+        extra_required=("port_velocity_ms", "fb_hz", "max_port_velocity_ms"),
+    )
+    return schema
+
+
+def sealed_simulation_schema() -> dict[str, dict[str, Any]]:
+    """Return both request and response schemas for the sealed solver."""
+
+    return {
+        "request": sealed_simulation_request_schema(),
+        "response": sealed_simulation_response_schema(),
+    }
+
+
+def vented_simulation_schema() -> dict[str, dict[str, Any]]:
+    """Return both request and response schemas for the vented solver."""
+
+    return {
+        "request": vented_simulation_request_schema(),
+        "response": vented_simulation_response_schema(),
+    }
+
+
+def solver_json_schemas() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return a catalog of solver schemas keyed by solver family."""
+
+    return {
+        "sealed": sealed_simulation_schema(),
+        "vented": vented_simulation_schema(),
+    }
+
+
+def _base_response_schema(
+    *,
+    title: str,
+    summary_schema: dict[str, Any],
+    extra_properties: Mapping[str, dict[str, Any]] | None = None,
+    extra_required: Sequence[str] = (),
+) -> dict[str, Any]:
+    properties: dict[str, dict[str, Any]] = {
+        "frequency_hz": _number_array_schema(
+            title="Frequency bins (Hz)",
+            min_items=1,
+            description="Frequencies where SPL/impedance were evaluated.",
+        ),
+        "spl_db": _number_array_schema(
+            title="Sound pressure level (dB)",
+            min_items=1,
+            description="Predicted on-axis SPL magnitude.",
+        ),
+        "impedance_real": _number_array_schema(
+            title="Electrical impedance (real)",
+            min_items=1,
+            description="Real component of electrical impedance (ohms).",
+        ),
+        "impedance_imag": _number_array_schema(
+            title="Electrical impedance (imag)",
+            min_items=1,
+            description="Imaginary component of electrical impedance (ohms).",
+        ),
+        "cone_velocity_ms": _number_array_schema(
+            title="Cone velocity (m/s)",
+            min_items=1,
+            description="Voice-coil/cone velocity magnitude.",
+        ),
+        "cone_displacement_m": _number_array_schema(
+            title="Cone displacement (m)",
+            min_items=1,
+            description="Instantaneous cone displacement magnitude.",
+        ),
+        "summary": summary_schema,
+    }
+
+    required = [
+        "frequency_hz",
+        "spl_db",
+        "impedance_real",
+        "impedance_imag",
+        "cone_velocity_ms",
+        "cone_displacement_m",
+        "summary",
+    ]
+
+    if extra_properties:
+        for name, prop in extra_properties.items():
+            properties[name] = dict(prop)
+    if extra_required:
+        required.extend(extra_required)
+
+    return {
+        "$schema": SCHEMA_DRAFT,
+        "title": title,
+        "type": "object",
+        "additionalProperties": False,
+        "properties": properties,
+        "required": required,
+    }
+
+
+def _schema_for_type(tp: Any) -> dict[str, Any]:
+    origin = get_origin(tp)
+
+    if origin is None:
+        if tp in (float,):
+            return {"type": "number"}
+        if tp in (int,):
+            return {"type": "integer"}
+        if tp in (str,):
+            return {"type": "string"}
+        if tp in (bool,):
+            return {"type": "boolean"}
+        if tp is type(None):
+            return {"type": "null"}
+        if isinstance(tp, type) and is_dataclass(tp):
+            return dataclass_schema(tp)
+        return {}
+
+    if origin in (list, Sequence, Iterable):
+        args = get_args(tp)
+        item_type = args[0] if args else Any
+        item_schema = _schema_for_type(item_type)
+        return {
+            "type": "array",
+            "items": item_schema or {},
+        }
+
+    if origin is tuple:
+        args = get_args(tp)
+        if len(args) == 2 and args[1] is Ellipsis:
+            return {
+                "type": "array",
+                "items": _schema_for_type(args[0]) or {},
+            }
+        return {
+            "type": "array",
+            "prefixItems": [_schema_for_type(arg) or {} for arg in args],
+            "items": False,
+        }
+
+    if origin in (dict, Mapping):
+        args = get_args(tp)
+        key_schema = _schema_for_type(args[0]) if args else {"type": "string"}
+        value_schema = _schema_for_type(args[1]) if len(args) > 1 else {}
+        return {
+            "type": "object",
+            "propertyNames": key_schema or {"type": "string"},
+            "additionalProperties": value_schema or {},
+        }
+
+    if origin is Union or origin is UnionType:
+        options = [_schema_for_type(arg) for arg in get_args(tp)]
+        # Collapse trivial unions like Union[T] back to T
+        options = [opt for opt in options if opt]
+        if not options:
+            return {}
+        if len(options) == 1:
+            return options[0]
+        return {"anyOf": options}
+
+    return {}
+
+
+def _number_array_schema(
+    *,
+    title: str | None = None,
+    min_items: int = 0,
+    description: str | None = None,
+) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "type": "array",
+        "items": {"type": "number"},
+    }
+    if min_items:
+        schema["minItems"] = min_items
+    if title:
+        schema["title"] = title
+    if description:
+        schema["description"] = description
+    return schema
+
+
+def _positive_number_schema(title: str | None = None, *, description: str | None = None) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "type": "number",
+        "exclusiveMinimum": 0.0,
+    }
+    if title:
+        schema["title"] = title
+    if description:
+        schema["description"] = description
+    return schema
+
+
+def _apply_override(schema: dict[str, Any], override: Mapping[str, Any]) -> None:
+    if "anyOf" in schema:
+        for option in schema["anyOf"]:
+            if option.get("type") == "null":
+                continue
+            option.update(override)
+    else:
+        schema.update(override)
+
+
+_DRIVER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
+    "fs_hz": {"exclusiveMinimum": 0.0},
+    "qts": {"exclusiveMinimum": 0.0},
+    "re_ohm": {"exclusiveMinimum": 0.0},
+    "bl_t_m": {"exclusiveMinimum": 0.0},
+    "mms_kg": {"exclusiveMinimum": 0.0},
+    "sd_m2": {"exclusiveMinimum": 0.0},
+    "le_h": {"minimum": 0.0},
+    "xmax_mm": {"exclusiveMinimum": 0.0},
+}
+
+_BOX_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
+    "volume_l": {"exclusiveMinimum": 0.0},
+    "leakage_q": {"exclusiveMinimum": 0.0},
+}
+
+_PORT_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
+    "diameter_m": {"exclusiveMinimum": 0.0},
+    "length_m": {"exclusiveMinimum": 0.0},
+    "count": {"minimum": 1},
+    "flare_factor": {"minimum": 0.0},
+    "loss_q": {"exclusiveMinimum": 0.0},
+}
+
+_VENTED_BOX_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
+    "volume_l": {"exclusiveMinimum": 0.0},
+    "leakage_q": {"exclusiveMinimum": 0.0},
+}
+
+_DATACLASS_OVERRIDES: dict[type[Any], dict[str, dict[str, Any]]] = {
+    DriverParameters: _DRIVER_FIELD_OVERRIDES,
+    BoxDesign: _BOX_FIELD_OVERRIDES,
+    PortGeometry: _PORT_FIELD_OVERRIDES,
+    VentedBoxDesign: _VENTED_BOX_FIELD_OVERRIDES,
+}
+
+
+__all__ = [
+    "dataclass_schema",
+    "sealed_simulation_request_schema",
+    "sealed_simulation_response_schema",
+    "sealed_simulation_schema",
+    "vented_simulation_request_schema",
+    "vented_simulation_response_schema",
+    "vented_simulation_schema",
+    "solver_json_schemas",
+]

--- a/python/tests/test_driver_parameters.py
+++ b/python/tests/test_driver_parameters.py
@@ -1,0 +1,57 @@
+import pathlib
+import sys
+import unittest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from spl_core import DriverParameters
+
+
+class DriverParameterUtilitiesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.driver = DriverParameters(
+            fs_hz=32.0,
+            qts=0.35,
+            re_ohm=5.4,
+            bl_t_m=16.2,
+            mms_kg=0.104,
+            sd_m2=0.082,
+            vas_l=95.0,
+            xmax_mm=12.0,
+        )
+
+    def test_compliance_curve_symmetry(self) -> None:
+        offsets = [-12.0, -6.0, 0.0, 6.0, 12.0]
+        curve = self.driver.compliance_curve(offsets)
+        self.assertEqual(len(curve), len(offsets))
+
+        midpoint = len(curve) // 2
+        for i in range(midpoint):
+            left = curve[i][1]
+            right = curve[-(i + 1)][1]
+            self.assertAlmostEqual(left, right, places=12)
+
+        cms_at_center = curve[midpoint][1]
+        cms_at_edge = curve[0][1]
+        self.assertGreater(cms_at_edge, cms_at_center)
+
+    def test_compliance_curve_without_xmax(self) -> None:
+        driver = DriverParameters(
+            fs_hz=29.5,
+            qts=0.41,
+            re_ohm=6.0,
+            bl_t_m=15.0,
+            mms_kg=0.12,
+            sd_m2=0.09,
+            vas_l=110.0,
+        )
+        curve = driver.compliance_curve([-5.0, 0.0, 5.0])
+        self.assertEqual(len(curve), 3)
+        self.assertGreater(curve[0][1], curve[1][1])
+
+    def test_xmax_conversion(self) -> None:
+        self.assertAlmostEqual(self.driver.xmax_m(), 0.012, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_gateway_store.py
+++ b/python/tests/test_gateway_store.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from services.gateway.app.store import RunStore
+
+
+class RunStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.NamedTemporaryFile(delete=False)
+        self._tmp.close()
+        self.store = RunStore(self._tmp.name)
+
+    def tearDown(self) -> None:
+        try:
+            os.remove(self._tmp.name)
+        except FileNotFoundError:
+            pass
+
+    def test_create_and_fetch(self) -> None:
+        record = self.store.create_run({"targetSpl": 118.0})
+        fetched = self.store.get_run(record.id)
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        self.assertEqual(fetched.status, "queued")
+        self.assertAlmostEqual(fetched.params["targetSpl"], 118.0)
+
+    def test_complete_run_updates_status(self) -> None:
+        record = self.store.create_run({"targetSpl": 110.0})
+        self.store.mark_running(record.id)
+        result = {"summary": {"fc_hz": 45.0}}
+        self.store.complete_run(record.id, result)
+        fetched = self.store.get_run(record.id)
+        assert fetched is not None
+        self.assertEqual(fetched.status, "succeeded")
+        self.assertEqual(fetched.result, result)
+
+    def test_mark_failed_sets_error(self) -> None:
+        record = self.store.create_run({})
+        self.store.mark_failed(record.id, "boom")
+        fetched = self.store.get_run(record.id)
+        assert fetched is not None
+        self.assertEqual(fetched.status, "failed")
+        self.assertEqual(fetched.error, "boom")
+
+    def test_list_runs_returns_newest_first(self) -> None:
+        first = self.store.create_run({"targetSpl": 100.0})
+        second = self.store.create_run({"targetSpl": 105.0})
+        runs = self.store.list_runs()
+        self.assertGreaterEqual(len(runs), 2)
+        self.assertEqual(runs[0].id, second.id)
+        self.assertEqual(runs[1].id, first.id)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/python/tests/test_sealed_box.py
+++ b/python/tests/test_sealed_box.py
@@ -1,0 +1,107 @@
+import math
+import pathlib
+import sys
+import unittest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from spl_core import BoxDesign, DriverParameters, SealedBoxSolver
+
+
+class SealedBoxSolverTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.driver = DriverParameters(
+            fs_hz=37.2,
+            qts=0.38,
+            re_ohm=5.6,
+            bl_t_m=17.0,
+            mms_kg=0.118,
+            sd_m2=0.0855,
+            le_h=0.0007,
+            vas_l=92.0,
+            xmax_mm=11.5,
+        )
+        self.box = BoxDesign(volume_l=50.0)
+        self.solver = SealedBoxSolver(self.driver, self.box)
+
+    def test_alignment_estimates(self) -> None:
+        fc = self.solver.system_resonance()
+        qtc = self.solver.system_qtc()
+        self.assertGreater(fc, self.driver.fs_hz)
+        self.assertTrue(50.0 < fc < 90.0)
+        self.assertTrue(0.5 < qtc < 1.2)
+
+    def test_frequency_response_shape(self) -> None:
+        fc = self.solver.system_resonance()
+        freqs = [fc / 2, fc, fc * 2]
+        response = self.solver.frequency_response(freqs)
+
+        self.assertEqual(len(response.frequency_hz), len(freqs))
+        self.assertEqual(len(response.spl_db), len(freqs))
+        self.assertEqual(len(response.impedance_ohm), len(freqs))
+        self.assertEqual(len(response.cone_displacement_m), len(freqs))
+
+        spl_low, spl_mid, spl_high = response.spl_db
+        self.assertGreater(spl_mid, spl_low)
+        self.assertGreater(spl_high, spl_mid)
+
+        v_low, v_mid, v_high = response.cone_velocity_ms
+        self.assertGreater(v_mid, v_low)
+        self.assertLess(v_high, v_mid)
+
+        d_low, d_mid, d_high = response.cone_displacement_m
+        self.assertAlmostEqual(d_low, v_low / (2 * math.pi * freqs[0]), places=6)
+        self.assertAlmostEqual(d_mid, v_mid / (2 * math.pi * freqs[1]), places=6)
+        self.assertAlmostEqual(d_high, v_high / (2 * math.pi * freqs[2]), places=6)
+
+        z_mag = abs(response.impedance_ohm[1])
+        self.assertGreater(z_mag, self.driver.re_ohm)
+
+        as_dict = response.to_dict()
+        self.assertIn("impedance_real", as_dict)
+        self.assertEqual(len(as_dict["impedance_real"]), len(freqs))
+        self.assertIn("cone_displacement_m", as_dict)
+
+    def test_alignment_summary_band_edges(self) -> None:
+        freqs = [float(f) for f in range(10, 201, 2)]
+        response = self.solver.frequency_response(freqs)
+        summary = self.solver.alignment_summary(response)
+
+        self.assertIsNotNone(summary.f3_low_hz)
+        self.assertIsNotNone(summary.f3_high_hz)
+        assert summary.f3_low_hz is not None
+        assert summary.f3_high_hz is not None
+        self.assertLess(summary.f3_low_hz, summary.fc_hz)
+        self.assertGreater(summary.f3_high_hz, summary.fc_hz)
+        self.assertGreater(summary.max_spl_db, response.spl_db[0])
+        self.assertGreater(summary.max_cone_velocity_ms, 0.0)
+        self.assertGreater(summary.max_cone_displacement_m, 0.0)
+        self.assertIsNotNone(summary.excursion_ratio)
+        assert summary.excursion_ratio is not None
+        self.assertGreater(summary.excursion_headroom_db or 0.0, -10.0)
+        self.assertIsNotNone(summary.safe_drive_voltage_v)
+
+        summary_dict = summary.to_dict()
+        fc_from_dict = summary_dict["fc_hz"]
+        assert fc_from_dict is not None
+        self.assertAlmostEqual(fc_from_dict, summary.fc_hz, places=6)
+        self.assertIn("max_cone_displacement_m", summary_dict)
+
+    def test_safe_drive_voltage_scaling(self) -> None:
+        freqs = [float(f) for f in range(15, 201, 5)]
+        response = self.solver.frequency_response(freqs)
+        summary = self.solver.alignment_summary(response)
+
+        self.assertIsNotNone(summary.safe_drive_voltage_v)
+        assert summary.safe_drive_voltage_v is not None
+
+        if summary.excursion_ratio and summary.excursion_ratio > 1.0:
+            self.assertLess(summary.safe_drive_voltage_v, self.solver.drive_voltage)
+        else:
+            self.assertAlmostEqual(
+                summary.safe_drive_voltage_v, self.solver.drive_voltage, places=6
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_serialization.py
+++ b/python/tests/test_serialization.py
@@ -1,0 +1,81 @@
+import pathlib
+import sys
+import unittest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from spl_core import (
+    sealed_simulation_request_schema,
+    sealed_simulation_response_schema,
+    solver_json_schemas,
+    vented_simulation_request_schema,
+    vented_simulation_response_schema,
+)
+
+
+class SchemaExportTests(unittest.TestCase):
+    def test_sealed_request_schema_structure(self) -> None:
+        schema = sealed_simulation_request_schema()
+        self.assertEqual(schema["type"], "object")
+        self.assertIn("driver", schema["required"])
+        driver = schema["properties"]["driver"]
+        self.assertEqual(driver["type"], "object")
+        self.assertIn("fs_hz", driver["properties"])
+        self.assertEqual(driver["properties"]["fs_hz"]["exclusiveMinimum"], 0.0)
+        self.assertIn("xmax_mm", driver["properties"])
+        xmax = driver["properties"]["xmax_mm"]
+        self.assertIn("anyOf", xmax)
+        number_opts = [opt for opt in xmax["anyOf"] if opt.get("type") == "number"]
+        self.assertTrue(number_opts)
+        self.assertEqual(number_opts[0]["exclusiveMinimum"], 0.0)
+        freq_schema = schema["properties"]["frequencies_hz"]
+        self.assertEqual(freq_schema["type"], "array")
+        self.assertEqual(freq_schema["items"]["type"], "number")
+        self.assertGreaterEqual(freq_schema["minItems"], 1)
+        self.assertNotIn("mic_distance_m", schema["required"])
+        self.assertNotIn("drive_voltage", schema["required"])
+
+    def test_sealed_response_schema_summary(self) -> None:
+        schema = sealed_simulation_response_schema()
+        self.assertIn("summary", schema["required"])
+        summary = schema["properties"]["summary"]
+        self.assertEqual(summary["type"], "object")
+        f3_low = summary["properties"]["f3_low_hz"]
+        self.assertIn("anyOf", f3_low)
+        self.assertTrue(any(option.get("type") == "null" for option in f3_low["anyOf"]))
+        self.assertIn("fc_hz", schema["required"])
+        self.assertIn("qtc", schema["required"])
+        self.assertIn("cone_displacement_m", schema["properties"])
+        self.assertIn("cone_displacement_m", schema["required"])
+
+    def test_vented_request_schema_includes_port(self) -> None:
+        schema = vented_simulation_request_schema()
+        box = schema["properties"]["box"]
+        self.assertIn("port", box["properties"])
+        port = box["properties"]["port"]
+        self.assertEqual(port["type"], "object")
+        self.assertEqual(port["properties"]["count"]["minimum"], 1)
+        self.assertEqual(port["properties"]["diameter_m"]["exclusiveMinimum"], 0.0)
+
+    def test_vented_response_schema_contains_port_velocity(self) -> None:
+        schema = vented_simulation_response_schema()
+        self.assertIn("port_velocity_ms", schema["properties"])
+        port_velocity = schema["properties"]["port_velocity_ms"]
+        self.assertEqual(port_velocity["type"], "array")
+        self.assertIn("fb_hz", schema["required"])
+        self.assertIn("max_port_velocity_ms", schema["required"])
+        self.assertIn("cone_displacement_m", schema["properties"])
+
+    def test_solver_catalog_lists_both_solvers(self) -> None:
+        catalog = solver_json_schemas()
+        self.assertIn("sealed", catalog)
+        self.assertIn("vented", catalog)
+        self.assertIn("request", catalog["sealed"])
+        self.assertEqual(
+            catalog["vented"]["response"]["title"],
+            "VentedBoxSimulationResponse",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_vented_box.py
+++ b/python/tests/test_vented_box.py
@@ -1,0 +1,101 @@
+import pathlib
+import sys
+import unittest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from spl_core import (
+    DriverParameters,
+    PortGeometry,
+    VentedBoxDesign,
+    VentedBoxSolver,
+)
+
+
+class VentedBoxSolverTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.driver = DriverParameters(
+            fs_hz=28.5,
+            qts=0.36,
+            re_ohm=3.4,
+            bl_t_m=15.5,
+            mms_kg=0.142,
+            sd_m2=0.089,
+            le_h=0.0008,
+            vas_l=140.0,
+            xmax_mm=13.0,
+        )
+
+        port = PortGeometry(diameter_m=0.1, length_m=0.22, count=1, loss_q=16.0)
+        self.box = VentedBoxDesign(volume_l=70.0, port=port, leakage_q=12.0)
+        self.solver = VentedBoxSolver(self.driver, self.box)
+
+    def test_tuning_frequency(self) -> None:
+        fb = self.solver.tuning_frequency()
+        self.assertTrue(28.0 < fb < 42.0)
+
+    def test_frequency_response_characteristics(self) -> None:
+        fb = self.solver.tuning_frequency()
+        freqs = [fb * 0.5, fb, fb * 2.0]
+        response = self.solver.frequency_response(freqs)
+
+        self.assertEqual(len(response.frequency_hz), 3)
+        self.assertEqual(len(response.port_air_velocity_ms), 3)
+        self.assertEqual(len(response.cone_displacement_m), 3)
+
+        # Port velocity should peak near tuning while cone velocity dips
+        port_low, port_fb, port_high = response.port_air_velocity_ms
+        cone_low, cone_fb, cone_high = response.cone_velocity_ms
+
+        self.assertGreater(port_fb, port_low)
+        self.assertGreater(port_fb, port_high)
+        self.assertLess(cone_fb, cone_low)
+        self.assertLess(response.cone_displacement_m[1], response.cone_displacement_m[0])
+
+        # SPL should rise meaningfully as we move above tuning
+        spl_low, spl_mid, spl_high = response.spl_db
+        self.assertLess(spl_low, spl_high)
+        self.assertLess(abs(spl_mid - spl_low), 12.0)
+
+        self.assertIn("port_velocity_ms", response.to_dict())
+        self.assertIn("cone_displacement_m", response.to_dict())
+
+    def test_impedance_double_peak(self) -> None:
+        freqs = [float(f) for f in range(20, 151, 5)]
+        response = self.solver.frequency_response(freqs)
+        mags = [abs(z) for z in response.impedance_ohm]
+
+        threshold = self.driver.re_ohm * 1.2
+        peak_count = 0
+        for i, mag in enumerate(mags):
+            if mag <= threshold:
+                continue
+            left = mags[i - 1] if i > 0 else mags[i + 1]
+            right = mags[i + 1] if i < len(mags) - 1 else mags[i - 1]
+            if mag >= left and mag >= right:
+                peak_count += 1
+
+        self.assertGreaterEqual(peak_count, 2)
+
+    def test_alignment_summary_port_metrics(self) -> None:
+        freqs = [float(f) for f in range(18, 181, 2)]
+        response = self.solver.frequency_response(freqs)
+        summary = self.solver.alignment_summary(response)
+
+        self.assertAlmostEqual(summary.fb_hz, self.solver.tuning_frequency(), places=6)
+        self.assertIsNotNone(summary.f3_low_hz)
+        self.assertIsNotNone(summary.f3_high_hz)
+        self.assertGreater(summary.max_port_velocity_ms, 0.0)
+        self.assertGreater(summary.max_cone_velocity_ms, 0.0)
+        self.assertGreater(summary.max_cone_displacement_m, 0.0)
+        self.assertGreater(summary.max_spl_db, response.spl_db[0])
+        self.assertIsNotNone(summary.excursion_ratio)
+        self.assertIsNotNone(summary.safe_drive_voltage_v)
+
+        summary_dict = summary.to_dict()
+        self.assertIn("max_port_velocity_ms", summary_dict)
+        self.assertIn("max_cone_displacement_m", summary_dict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/gateway/app/__init__.py
+++ b/services/gateway/app/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI gateway package."""

--- a/services/gateway/app/store.py
+++ b/services/gateway/app/store.py
@@ -1,0 +1,159 @@
+"""Persistence helpers for optimization runs."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DB_PATH = Path(__file__).resolve().parent / "gateway.db"
+
+
+@dataclass(slots=True)
+class RunRecord:
+    """Represents a persisted optimisation run."""
+
+    id: str
+    status: str
+    created_at: float
+    updated_at: float
+    params: dict[str, Any]
+    result: dict[str, Any] | None
+    error: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "params": self.params,
+            "result": self.result,
+            "error": self.error,
+        }
+
+
+class RunStore:
+    """Lightweight SQLite-backed store for optimisation runs."""
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self._path = Path(db_path) if db_path else DEFAULT_DB_PATH
+        parent = self._path.parent
+        if str(parent) not in {"", "."} and not parent.exists():
+            parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            str(self._path), timeout=30, isolation_level=None, check_same_thread=False
+        )
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS runs (
+                    id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    params TEXT NOT NULL,
+                    result TEXT,
+                    error TEXT
+                )
+                """
+            )
+
+    def create_run(self, params: dict[str, Any]) -> RunRecord:
+        now = time.time()
+        run_id = uuid.uuid4().hex
+        record = RunRecord(
+            id=run_id,
+            status="queued",
+            created_at=now,
+            updated_at=now,
+            params=dict(params),
+            result=None,
+            error=None,
+        )
+        payload = (run_id, record.status, now, now, json.dumps(record.params), None, None)
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    "INSERT INTO runs (id, status, created_at, updated_at, params, result, error) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    payload,
+                )
+        return record
+
+    def mark_running(self, run_id: str) -> None:
+        self._update_status(run_id, "running", result=None, error=None)
+
+    def complete_run(self, run_id: str, result: dict[str, Any]) -> None:
+        self._update_status(run_id, "succeeded", result=result, error=None)
+
+    def mark_failed(self, run_id: str, error: str) -> None:
+        self._update_status(run_id, "failed", result=None, error=error)
+
+    def _update_status(
+        self,
+        run_id: str,
+        status: str,
+        *,
+        result: dict[str, Any] | None,
+        error: str | None,
+    ) -> None:
+        now = time.time()
+        result_json = json.dumps(result) if result is not None else None
+        with self._lock:
+            with self._connect() as conn:
+                cursor = conn.execute(
+                    "UPDATE runs SET status = ?, updated_at = ?, result = ?, error = ? WHERE id = ?",
+                    (status, now, result_json, error, run_id),
+                )
+                if cursor.rowcount == 0:
+                    raise KeyError(f"Unknown run id: {run_id}")
+
+    def get_run(self, run_id: str) -> RunRecord | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
+        if row is None:
+            return None
+        return self._row_to_record(row)
+
+    def list_runs(self, *, limit: int = 20) -> list[RunRecord]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM runs ORDER BY created_at DESC LIMIT ?",
+                (max(limit, 1),),
+            ).fetchall()
+        return [self._row_to_record(row) for row in rows]
+
+    def delete_all(self) -> None:
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute("DELETE FROM runs")
+
+    def _row_to_record(self, row: sqlite3.Row) -> RunRecord:
+        params = json.loads(row["params"]) if row["params"] else {}
+        result = json.loads(row["result"]) if row["result"] else None
+        error = row["error"] if row["error"] else None
+        return RunRecord(
+            id=row["id"],
+            status=row["status"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            params=params,
+            result=result,
+            error=error,
+        )
+
+
+__all__ = ["RunStore", "RunRecord"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@core/*": ["packages/web-ui/src/core/*"],
+      "@components/*": ["packages/web-ui/src/components/*"],
+      "@stores/*": ["packages/web-ui/src/stores/*"],
+      "@lib/*": ["packages/web-ui/src/lib/*"],
+      "@types/*": ["packages/web-ui/src/types/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a SQLite-backed optimisation run store with background task execution and new FastAPI endpoints for creating and fetching optimisation runs
- update the Studio optimisation store and dev mocks to poll the new run API, track active run IDs, and surface convergence data in the HUD
- document the roadmap progress increase and add unit tests covering the run persistence layer

## Testing
- python -m unittest discover -s python/tests
- python -m ruff check services/gateway/app python/tests/test_gateway_store.py
- python -m mypy services/gateway/app
- pnpm lint *(fails: registry access blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c0a11b708323a218cd804d5e5011